### PR TITLE
Camelcased keys in JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ end
 * [Creating pages](https://github.com/iZettle/ninetails/wiki/Creating-pages)
 * [Publishing pages](https://github.com/iZettle/ninetails/wiki/Publishing-pages)
 * [Validating properties](https://github.com/iZettle/ninetails/wiki/Validating-properties)
+
+## Configuration
+
+By default, Ninetails will force all keys in JSON responses to be camelcase with the first letter lowercase, to conform with JSON standards. If you would prefer the output to be as underscored, you can set this in an initializer:
+
+```ruby
+Ninetails::Config.key_style = :underscore
+```

--- a/lib/ninetails/config.rb
+++ b/lib/ninetails/config.rb
@@ -1,0 +1,8 @@
+module Ninetails
+  class Config
+
+    cattr_accessor :key_style
+    self.key_style = :camelcase
+
+  end
+end

--- a/lib/ninetails/engine.rb
+++ b/lib/ninetails/engine.rb
@@ -9,6 +9,9 @@ require "jbuilder"
 require "hash-pipe"
 require "virtus"
 
+require "ninetails/config"
+require "ninetails/key_conversion"
+
 begin
   require "pry"
 rescue LoadError
@@ -17,6 +20,8 @@ end
 module Ninetails
   class Engine < ::Rails::Engine
     isolate_namespace Ninetails
+
+    middleware.use "Ninetails::KeyConversion"
 
     config.generators do |g|
       g.test_framework :rspec, fixture: false

--- a/lib/ninetails/key_conversion.rb
+++ b/lib/ninetails/key_conversion.rb
@@ -1,0 +1,28 @@
+module Ninetails
+  class KeyConversion
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @status, @headers, @response = @app.call(env)
+
+      if @response.respond_to? :body
+        [@status, @headers, [modify_keys(@response.body)]]
+      else
+        [@status, @headers, @response]
+      end
+    end
+
+    def modify_keys(body)
+      if @headers["Content-Type"].include?("application/json") && Ninetails::Config.key_style == :camelcase
+        body = JSON.parse(body).convert_keys -> (key) { key.camelcase :lower }
+        body.to_json
+      else
+        body
+      end
+    end
+
+  end
+end

--- a/spec/dummy/config/initializers/ninetails.rb
+++ b/spec/dummy/config/initializers/ninetails.rb
@@ -1,0 +1,1 @@
+Ninetails::Config.key_style = :underscore

--- a/spec/requests/middleware_spec.rb
+++ b/spec/requests/middleware_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+module Ninetails
+  class TestController < ApplicationController
+    def index
+      render json: {
+        foo_bar: "baz_box",
+        hello_world: {
+          this_is_dog_fort: "Checking in"
+        }
+      }
+    end
+
+    def show
+      render text: "foo_bar"
+    end
+  end
+end
+
+class DummyController < ActionController::Base
+  def index
+    render json: {
+      this_is_a_key: "thanks"
+    }
+  end
+end
+
+describe "Key conversion middleware" do
+
+  # Add the Ninetails::TestController and DummyController stuff to routes
+  before do
+    Ninetails::Engine.routes.send(:eval_block, -> {
+      get "/test", to: "test#index"
+      get "/test/foo", to: "test#show"
+    })
+
+    Dummy::Application.routes.send(:eval_block, -> {
+      get "/dummy", to: "dummy#index"
+    })
+  end
+
+  describe "when Ninetails::Config.key_style is camelcase" do
+    before do
+      Ninetails::Config.key_style = :camelcase
+    end
+
+    it "should convert all keys to camelcase" do
+      get "/test"
+      expect(json).to have_key "fooBar"
+      expect(json["helloWorld"]).to have_key "thisIsDogFort"
+    end
+
+    it "should not modify non-json responses" do
+      get "/test/foo"
+      expect(response.body).to eq "foo_bar"
+    end
+
+    it "should not modify responses from outside of the Ninetails engine" do
+      get "/dummy"
+      expect(json).to have_key "this_is_a_key"
+    end
+  end
+
+  describe "when Ninetails::Config.key_style is underscore" do
+    before do
+      Ninetails::Config.key_style = :underscore
+    end
+
+    it "should not modify any response from Ninetails" do
+      get "/test"
+      expect(json).to have_key "foo_bar"
+    end
+
+    it "should not modify any response from the parent app" do
+      get "/dummy"
+      expect(json).to have_key "this_is_a_key"
+    end
+  end
+
+end

--- a/spec/requests/sections_spec.rb
+++ b/spec/requests/sections_spec.rb
@@ -5,8 +5,8 @@ describe "Sections API" do
   it "should list the available sections" do
     get "/sections"
     expect(response).to be_success
-    billboardJson = json["sections"].find { |s| s["type"] == "Billboard" }.to_json
-    expect(billboardJson).to eq Section::Billboard.new.serialize.to_json
+    billboard_json = json["sections"].find { |s| s["type"] == "Billboard" }.to_json
+    expect(billboard_json).to eq Section::Billboard.new.serialize.to_json
   end
 
   it "should be possible to get a section's structure" do


### PR DESCRIPTION
Optionally using Rack middleware to convert keys in JSON responses to be camelcased. This means we can refer to Section, Element, and Property structures internally using Ruby standards, while ensuring that a JS-based consumer of the API can always reliably receive camelcased JSON.

This is enabled by default, but can be set using `Ninetails::Config.key_style`:

``` ruby
Ninetails::Config.key_style = :underscore
Ninetails::Config.key_style = :camelcase
```

@iZettle/web
