### PR TITLE
Notes on elements in sections

### DIFF
--- a/app/components/ninetails/element.rb
+++ b/app/components/ninetails/element.rb
@@ -11,6 +11,7 @@ module Ninetails
     end
 
     def deserialize(input)
+      # self.note = input["note"] if input["note"].present?
       properties_instances.collect do |property|
         property.serialized_values = input[property.name.to_s]
       end
@@ -47,6 +48,7 @@ module Ninetails
       properties_instances.each_with_object({}) do |property_type, hash|
         hash[:type] = name
         hash[:reference] = reference
+        hash[:note] = note if note.present?
         hash[property_type.name] = property_type.serialize
 
         if property_type.property.try(:errors).try(:present?)

--- a/app/components/ninetails/element.rb
+++ b/app/components/ninetails/element.rb
@@ -11,7 +11,6 @@ module Ninetails
     end
 
     def deserialize(input)
-      # self.note = input["note"] if input["note"].present?
       properties_instances.collect do |property|
         property.serialized_values = input[property.name.to_s]
       end

--- a/app/components/ninetails/element_definition.rb
+++ b/app/components/ninetails/element_definition.rb
@@ -1,13 +1,14 @@
 module Ninetails
   class ElementDefinition
-    attr_accessor :name, :type, :count, :elements
+    attr_accessor :name, :type, :count, :elements, :options
 
     delegate :properties, to: :type
 
-    def initialize(name, type, count)
+    def initialize(name, type, count, options={})
       @name = name
       @type = type
       @count = count
+      @options = options
       @elements = []
     end
 
@@ -32,7 +33,7 @@ module Ninetails
     end
 
     def properties_structure
-      @properties_structure ||= type.new.properties_structure
+      @properties_structure ||= type.new(options).properties_structure
     end
 
     def all_elements_valid?
@@ -59,6 +60,7 @@ module Ninetails
 
     def add_element(input)
       element = type.new
+      element.note = options[:note] if options[:note].present?
       element.deserialize input
       elements << element
     end

--- a/app/components/ninetails/property_store.rb
+++ b/app/components/ninetails/property_store.rb
@@ -5,6 +5,8 @@ module Ninetails
     included do
       include Virtus.model
       include ActiveModel::Validations
+
+      attribute :note, String
     end
 
     class_methods do

--- a/app/components/ninetails/section.rb
+++ b/app/components/ninetails/section.rb
@@ -16,17 +16,17 @@ module Ninetails
       @position
     end
 
-    def self.define_element(name, type, count)
+    def self.define_element(name, type, count, options={})
       @elements ||= []
-      @elements << Ninetails::ElementDefinition.new(name, type, count)
+      @elements << Ninetails::ElementDefinition.new(name, type, count, options)
     end
 
-    def self.has_element(name, type)
-      define_element name, type, :single
+    def self.has_element(name, type, options={})
+      define_element name, type, :single, options
     end
 
-    def self.has_many_elements(name, type)
-      define_element name, type, :multiple
+    def self.has_many_elements(name, type, options={})
+      define_element name, type, :multiple, options
     end
 
     def self.elements

--- a/spec/components/element_definition_spec.rb
+++ b/spec/components/element_definition_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe Ninetails::ElementDefinition do
 
-  let(:text_element) { Ninetails::ElementDefinition.new(:foo, Element::Text, :single) }
+  let(:text_element) { Ninetails::ElementDefinition.new(:foo, Element::Text, :single, note: "Foo bar note") }
 
   it "should store the name of the element" do
     expect(text_element.name).to eq :foo
@@ -24,6 +24,10 @@ describe Ninetails::ElementDefinition do
 
   it "should store the count of the element" do
     expect(text_element.count).to eq :single
+  end
+
+  it "should store the note in the options attribute" do
+    expect(text_element.options[:note]).to eq "Foo bar note"
   end
 
   describe "adding type structure with singles" do
@@ -70,6 +74,17 @@ describe Ninetails::ElementDefinition do
 
         definition.deserialize hash
       end
+
+      it "should not set the note on the element if it is not in the definition" do
+        definition.deserialize hash
+        expect(definition.elements.first.note).to be_nil
+      end
+
+      it "should set the note on the element if it is in the definition" do
+        definition.options[:note] = "This is a note"
+        definition.deserialize hash
+        expect(definition.elements.first.note).to eq "This is a note"
+      end
     end
 
     describe "multiple elements" do
@@ -96,6 +111,14 @@ describe Ninetails::ElementDefinition do
         expect(second_element_instance).to receive(:deserialize).with(hash[1])
 
         definition.deserialize hash
+      end
+
+      it "should set the note on each element if it is in the definition" do
+        definition.options[:note] = "Some note"
+        definition.deserialize hash
+        definition.elements.each do |element|
+          expect(element.note).to eq "Some note"
+        end
       end
 
     end

--- a/spec/components/element_spec.rb
+++ b/spec/components/element_spec.rb
@@ -19,6 +19,10 @@ class ElementForValidating < Ninetails::Element
   property :something, CustomProperty
 end
 
+class ElementWithNote < Ninetails::Element
+  property :title, CustomProperty
+end
+
 RSpec.describe Ninetails::Element do
 
   describe "properties" do
@@ -44,8 +48,8 @@ RSpec.describe Ninetails::Element do
     end
   end
 
-  describe "serialization" do
-    let(:element) { ExampleElement.new }
+  describe "properties_structure" do
+    let(:element) { ExampleElement.new note: "Foo bar" }
     let(:structure) { element.properties_structure }
 
     it "should be a hash" do
@@ -64,6 +68,10 @@ RSpec.describe Ninetails::Element do
       expect(structure[:foo]).to eq nil
       expect(structure[:bar]).to eq nil
     end
+
+    it "should include the note" do
+      expect(structure[:note]).to eq "Foo bar"
+    end
   end
 
   describe "deserialization" do
@@ -76,6 +84,23 @@ RSpec.describe Ninetails::Element do
       expect(element.send(:properties_instances).first).to receive(:serialized_values=).with("text"=>"hello")
       expect(element.send(:properties_instances).last).to receive(:serialized_values=).with("text"=>"world")
       element.deserialize hash
+    end
+  end
+
+  describe "notes" do
+    let(:element) { ElementWithNote.new note: "Foo bar" }
+    let(:hash) do
+      {"type"=>"ElementWithNote","note"=>"shouldn't change","title"=>{"text"=>"hello"}}
+    end
+
+    it "should store the note on the Element" do
+      expect(element.note).to eq "Foo bar"
+    end
+
+    it "deserialization should not modify the note" do
+      expect {
+        element.deserialize hash
+      }.to_not change { element.note }
     end
   end
 

--- a/spec/components/property_store_spec.rb
+++ b/spec/components/property_store_spec.rb
@@ -38,7 +38,7 @@ describe Ninetails::PropertyStore do
   end
 
   it "should store the property as a virtus attribute" do
-    virtus_attr = SomeProperties.attribute_set.first
+    virtus_attr = SomeProperties.attribute_set.find { |a| a.name == :text}
     expect(virtus_attr.name).to eq :text
     expect(virtus_attr.primitive).to eq Property::Text
   end

--- a/spec/components/section_spec.rb
+++ b/spec/components/section_spec.rb
@@ -6,6 +6,11 @@ class ExampleSection < Ninetails::Section
   has_element :bar, Element::Button
 end
 
+class SectionWithNote < Ninetails::Section
+  located_in :body
+  has_element :foo, Element::Text, note: "This is a note"
+end
+
 RSpec.describe Ninetails::Section do
 
   describe "position" do
@@ -32,6 +37,10 @@ RSpec.describe Ninetails::Section do
       expect(ExampleSection.elements[0].type).to eq Element::Text
       expect(ExampleSection.elements[1].type).to eq Element::Button
     end
+
+    it "should store notes on the element" do
+      expect(SectionWithNote.elements[0].options[:note]).to eq "This is a note"
+    end
   end
 
   describe "elements structure" do
@@ -42,14 +51,31 @@ RSpec.describe Ninetails::Section do
     end
 
     let(:structure) { ExampleSection.new.serialize_elements }
+    let(:note_section_structure) { SectionWithNote.new.serialize_elements }
+
+    let(:foo_structure) do
+      {"type"=>"Text", "reference"=>"123", "content"=>{"reference"=>"123", "text"=>nil}}
+    end
+
+    let(:bar_structure) do
+      {"type"=>"Button", "reference"=>"123", "link"=>{"reference"=>"123", "url"=>nil, "title"=>nil, "text"=>nil}}
+    end
+
+    let(:note_structure) do
+      {"type"=>"Text", "reference"=>"123", "note"=>"This is a note", "content"=>{"reference"=>"123", "text"=>nil}}
+    end
 
     it "should be a hash" do
       expect(structure).to be_a(Hash)
     end
 
     it "should have the property structure for each element" do
-      expect(structure[:foo]).to eq Ninetails::ElementDefinition.new(:bogus, Element::Text, :single).properties_structure
-      expect(structure[:bar]).to eq Ninetails::ElementDefinition.new(:bogus, Element::Button, :single).properties_structure
+      expect(structure[:foo]).to eq foo_structure
+      expect(structure[:bar]).to eq bar_structure
+    end
+
+    it "should include the note if the element has one" do
+      expect(note_section_structure[:foo]).to eq note_structure
     end
   end
 

--- a/spec/dummy/app/components/section/billboard.rb
+++ b/spec/dummy/app/components/section/billboard.rb
@@ -3,7 +3,7 @@ module Section
 
     located_in :body
 
-    has_element :title, Element::Text
+    has_element :title, Element::Text, note: "This should be kept short"
     has_element :background_image, Element::Figure
     has_element :signup_button, Element::Button
 


### PR DESCRIPTION
Making it possible to write notes on elements when adding them to section definitions, so that they can then be used when building admin areas for managing sections (so you can explain a little about how an element should behave). Works kinda like this:

``` ruby
class SomeSection < Ninetails::Section
  located_in :body
  has_element :link, Property::Link, note: "This should link to something..."
end
```

And then the structure for this would be like (with some structure omitted for clarity):

``` json
{
  "type": "SomeSection",
  "elements": {
    "link": {
      "type": "Link",
      "note": "This should link to something..",
      "link": "..."
    }
  }
}
```

@marreman what do you think?
