### PR TITLE
Projects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,8 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     shellany (0.0.1)
+    shoulda-matchers (3.1.0)
+      activesupport (>= 4.0.0)
     simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -221,6 +223,7 @@ DEPENDENCIES
   ninetails!
   pry (~> 0.10)
   rspec-rails (~> 3.3)
+  shoulda-matchers (~> 3.1)
   spring (~> 1.6)
   spring-commands-rspec (~> 1.0)
   web-console (~> 2.2)

--- a/app/controllers/ninetails/projects_controller.rb
+++ b/app/controllers/ninetails/projects_controller.rb
@@ -1,0 +1,35 @@
+module Ninetails
+  class ProjectsController < ApplicationController
+
+    def index
+      @projects = Project.all
+    end
+
+    def create
+      @project = Project.new project_params
+
+      if @project.save
+        render :show, status: :created
+      else
+        render :show, status: :bad_request
+      end
+    end
+
+    def update
+      @project = Project.find params[:id]
+
+      if @project.update_attributes project_params
+        render :show, status: :ok
+      else
+        render :show, status: :bad_request
+      end
+    end
+
+    private
+
+    def project_params
+      params.require(:project).permit(:name, :description)
+    end
+
+  end
+end

--- a/app/models/ninetails/page.rb
+++ b/app/models/ninetails/page.rb
@@ -13,7 +13,7 @@ module Ninetails
 
     def build_revision_from_params(page_revision)
       page_revision = page_revision.convert_keys(:underscore).with_indifferent_access
-      self.revision = revisions.build message: page_revision[:message]
+      self.revision = revisions.build message: page_revision[:message], project_id: page_revision[:project_id]
 
       page_revision[:sections].each do |section_json|
         revision.sections.build section_json.except(:id)

--- a/app/models/ninetails/page_revision.rb
+++ b/app/models/ninetails/page_revision.rb
@@ -1,6 +1,8 @@
 module Ninetails
   class PageRevision < ActiveRecord::Base
+
     belongs_to :page
+    belongs_to :project
     has_many :page_revision_sections
     has_many :sections, through: :page_revision_sections
 

--- a/app/models/ninetails/page_revision.rb
+++ b/app/models/ninetails/page_revision.rb
@@ -8,6 +8,8 @@ module Ninetails
 
     validate :sections_are_all_valid
 
+    after_create :update_project_page, if: -> { project.present? }
+
     private
 
     # Validate all sections and rebuild the sections array with the instances which now
@@ -18,6 +20,12 @@ module Ninetails
           errors.add :base, section.errors.messages[:base]
         end
       end
+    end
+
+    def update_project_page
+      project_page = ProjectPage.find_or_initialize_by project_id: project.id, page_id: page.id
+      project_page.page_revision = self
+      project_page.save
     end
 
   end

--- a/app/models/ninetails/project.rb
+++ b/app/models/ninetails/project.rb
@@ -1,0 +1,8 @@
+module Ninetails
+  class Project < ActiveRecord::Base
+
+    has_many :project_pages
+    has_many :pages, through: :project_pages
+
+  end
+end

--- a/app/models/ninetails/project.rb
+++ b/app/models/ninetails/project.rb
@@ -4,5 +4,7 @@ module Ninetails
     has_many :project_pages
     has_many :pages, through: :project_pages
 
+    validates :name, presence: true
+
   end
 end

--- a/app/models/ninetails/project_page.rb
+++ b/app/models/ninetails/project_page.rb
@@ -5,8 +5,24 @@ module Ninetails
     belongs_to :page_revision
     belongs_to :project
 
-    validates :page_revision, uniqueness: { scope: :project, message: "has already been set for this page in the project" }
-    validates :page, uniqueness: { scope: :project, message: "is already used in this project" }
+    validates :project, {
+      presence: true
+    }
+
+    validates :page_revision, {
+      uniqueness: {
+        scope: :project,
+        message: "has already been set for this page in the project"
+      }
+    }
+
+    validates :page, {
+      presence: true,
+      uniqueness: {
+        scope: :project,
+        message: "is already used in this project"
+      }
+    }
 
   end
 end

--- a/app/models/ninetails/project_page.rb
+++ b/app/models/ninetails/project_page.rb
@@ -1,0 +1,12 @@
+module Ninetails
+  class ProjectPage < ActiveRecord::Base
+
+    belongs_to :page
+    belongs_to :page_revision
+    belongs_to :project
+
+    validates :page_revision, uniqueness: { scope: :project, message: "has already been set for this page in the project" }
+    validates :page, uniqueness: { scope: :project, message: "is already used in this project" }
+
+  end
+end

--- a/app/views/ninetails/projects/index.json.jbuilder
+++ b/app/views/ninetails/projects/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.projects @projects, :id, :name, :description

--- a/app/views/ninetails/projects/show.json.jbuilder
+++ b/app/views/ninetails/projects/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.project do
+  json.call @project, :id, :name, :description
+
+  if @project.errors.present?
+    json.errors @project.errors
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Ninetails::Engine.routes.draw do
   with_options defaults: { format: :json } do
     root 'pages#index'
 
+    resources :projects
+
     resources :pages, only: [:show, :create, :index] do
       resources :page_revisions, only: [:create, :show, :index], path: "revisions"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Ninetails::Engine.routes.draw do
   with_options defaults: { format: :json } do
     root 'pages#index'
 
-    resources :projects
+    resources :projects, only: [:create, :update, :index]
 
     resources :pages, only: [:show, :create, :index] do
       resources :page_revisions, only: [:create, :show, :index], path: "revisions"

--- a/db/migrate/20160121112852_create_projects.rb
+++ b/db/migrate/20160121112852_create_projects.rb
@@ -1,0 +1,8 @@
+class CreateProjects < ActiveRecord::Migration
+  def change
+    create_table :ninetails_projects do |t|
+      t.string :name
+      t.string :description
+    end
+  end
+end

--- a/db/migrate/20160121121904_create_project_pages.rb
+++ b/db/migrate/20160121121904_create_project_pages.rb
@@ -1,0 +1,9 @@
+class CreateProjectPages < ActiveRecord::Migration
+  def change
+    create_table :ninetails_project_pages do |t|
+      t.belongs_to :project
+      t.belongs_to :page
+      t.belongs_to :page_revision
+    end
+  end
+end

--- a/db/migrate/20160121135155_add_project_id_to_page_revisions.rb
+++ b/db/migrate/20160121135155_add_project_id_to_page_revisions.rb
@@ -1,0 +1,5 @@
+class AddProjectIdToPageRevisions < ActiveRecord::Migration
+  def change
+    add_reference :ninetails_page_revisions, :project
+  end
+end

--- a/ninetails.gemspec
+++ b/ninetails.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "factory_girl", "~> 4.5"
   s.add_development_dependency "factory_girl_rails", "~> 4.5"
   s.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
+  s.add_development_dependency "shoulda-matchers", "~> 3.1"
 
   s.test_files = Dir["spec/**/*"]
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151120120538) do
+ActiveRecord::Schema.define(version: 20160121135155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20151120120538) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "message"
+    t.integer  "project_id"
   end
 
   create_table "ninetails_page_sections", force: :cascade do |t|
@@ -49,5 +50,16 @@ ActiveRecord::Schema.define(version: 20151120120538) do
   end
 
   add_index "ninetails_pages", ["current_revision_id"], name: "index_ninetails_pages_on_current_revision_id", using: :btree
+
+  create_table "ninetails_project_pages", force: :cascade do |t|
+    t.integer "project_id"
+    t.integer "page_id"
+    t.integer "page_revision_id"
+  end
+
+  create_table "ninetails_projects", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+  end
 
 end

--- a/spec/factories/project_pages.rb
+++ b/spec/factories/project_pages.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+
+  factory :project_page, class: Ninetails::ProjectPage do
+    project
+    page
+
+    after :create do |project_page, evaluator|
+      revision = create :page_revision, page: project_page.page, project: project_page.project
+      project_page.update page_revision: revision
+    end
+  end
+
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
 
   factory :project, class: Ninetails::Project do
-    name "A project"
+    sequence(:name) { |n| "Some project #{n}" }
     description "This is a project about things"
   end
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+
+  factory :project, class: Ninetails::Project do
+    name "A project"
+    description "This is a project about things"
+  end
+
+end

--- a/spec/models/page_revision_spec.rb
+++ b/spec/models/page_revision_spec.rb
@@ -2,4 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Ninetails::PageRevision, type: :model do
 
+  it { should belong_to(:page) }
+  it { should belong_to(:project) }
+  it { should have_many(:page_revision_sections) }
+  it { should have_many(:sections) }
+
+  # TODO: Write missing tests!
+
 end

--- a/spec/models/project_page_spec.rb
+++ b/spec/models/project_page_spec.rb
@@ -2,13 +2,30 @@ require 'rails_helper'
 
 describe Ninetails::ProjectPage do
 
-  let(:project_page) { create :project_page }
+  let(:existing_page) { create :project_page }
+
+  it "should require a project" do
+    project_page = build :project_page, project: nil
+    expect(project_page.valid?).to be false
+    expect(project_page.errors[:project]).to include "can't be blank"
+  end
+
+  it "should require a page" do
+    project_page = build :project_page, page: nil
+    expect(project_page.valid?).to be false
+    expect(project_page.errors[:page]).to include "can't be blank"
+  end
+
+  it "should not require a page revision" do
+    project_page = build :project_page, page_revision: nil
+    expect(project_page.valid?).to be true
+  end
 
   describe "validating uniqueness of the page revision" do
-    let(:duplicate_revision) { Ninetails::ProjectPage.new page_revision: project_page.page_revision }
-    let(:duplicate_page) { Ninetails::ProjectPage.new page: project_page.page }
-    let(:duplicate_revsion_in_project) { Ninetails::ProjectPage.new page_revision: project_page.page_revision, project: project_page.project }
-    let(:duplicate_page_in_project) { Ninetails::ProjectPage.new page: project_page.page, project: project_page.project }
+    let(:duplicate_revision) { build :project_page, page_revision: existing_page.page_revision }
+    let(:duplicate_page) { build :project_page, page: existing_page.page }
+    let(:duplicate_revsion_in_project) { build :project_page, page_revision: existing_page.page_revision, project: existing_page.project }
+    let(:duplicate_page_in_project) { build :project_page, page: existing_page.page, project: existing_page.project }
 
     it "should allow the same revision to be referenced in multiple projects" do
       expect(duplicate_revision.valid?).to be true

--- a/spec/models/project_page_spec.rb
+++ b/spec/models/project_page_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Ninetails::ProjectPage do
+
+  let(:project_page) { create :project_page }
+
+  describe "validating uniqueness of the page revision" do
+    let(:duplicate_revision) { Ninetails::ProjectPage.new page_revision: project_page.page_revision }
+    let(:duplicate_page) { Ninetails::ProjectPage.new page: project_page.page }
+    let(:duplicate_revsion_in_project) { Ninetails::ProjectPage.new page_revision: project_page.page_revision, project: project_page.project }
+    let(:duplicate_page_in_project) { Ninetails::ProjectPage.new page: project_page.page, project: project_page.project }
+
+    it "should allow the same revision to be referenced in multiple projects" do
+      expect(duplicate_revision.valid?).to be true
+    end
+
+    it "should allow the same page to be referenced in multiple projects" do
+      expect(duplicate_page.valid?).to be true
+    end
+
+    it "should not allow the same page to have multiple revisions in the project" do
+      expect(duplicate_revsion_in_project.valid?).to be false
+      expect(duplicate_revsion_in_project.errors[:page_revision]).to include "has already been set for this page in the project"
+    end
+
+    it "should not allow the same page to be used in the same project" do
+      expect(duplicate_page_in_project.valid?).to be false
+      expect(duplicate_page_in_project.errors[:page]).to include "is already used in this project"
+    end
+  end
+
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Ninetails::Project do
+
+  let(:project) { create :project }
+
+  before do
+    create_list :project_page, 3, project: project
+  end
+
+  it "should have many project pages" do
+    expect(project.project_pages.count).to eq 3
+  end
+
+  it "should have many pages through project pages" do
+    expect(project.pages.count).to eq 3
+  end
+
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -16,4 +16,10 @@ describe Ninetails::Project do
     expect(project.pages.count).to eq 3
   end
 
+  it "should require a name" do
+    invalid_project = build :project, name: nil
+    expect(invalid_project.valid?).to be false
+    expect(invalid_project.errors[:name]).to include "can't be blank"
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ ActiveRecord::Migrator.migrations_paths << [File.expand_path('./../../db/migrate
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'shoulda-matchers'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'factory_girl'
@@ -57,4 +58,11 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe "Projects API" do
+
+  describe "listing projects" do
+    before do
+      create_list :project, 5
+    end
+
+    it "should return the correct number of projects" do
+      get "/projects"
+      expect(response).to be_success
+      expect(json["projects"].size).to eq 5
+    end
+
+    it "should include the id, name, and description for each project" do
+      get "/projects"
+
+      json["projects"].each do |project|
+        expect(project).to have_key "id"
+        expect(project).to have_key "name"
+        expect(project).to have_key "description"
+      end
+    end
+  end
+
+  describe "creating projects" do
+    let(:valid_project_params) { attributes_for(:project) }
+    let(:invalid_project_params) { attributes_for :project, name: nil }
+
+    it "should save the project if it is valid" do
+      expect {
+        post "/projects", project: valid_project_params
+      }.to change{ Ninetails::Project.count }.by(1)
+    end
+
+    it "should show errors if the name is blank" do
+      post "/projects", project: invalid_project_params
+
+      expect(response).to_not be_success
+      expect(json["project"]["errors"]["name"]).not_to be_empty
+    end
+  end
+
+  describe "updating projects" do
+    let(:project) { create :project }
+    let(:new_valid_attributes) { attributes_for :project }
+    let(:new_invalid_attributes) { attributes_for :project, name: nil }
+
+    before do
+      # call factory girl so the project exists before the tests run
+      project
+    end
+
+    it "should update the project if it is valid" do
+      put "/projects/#{project.id}", project: new_valid_attributes
+
+      expect(response).to be_success
+      expect(Ninetails::Project.find(project.id).name).not_to eq project.name
+    end
+
+    it "should not update the project if it is invalid" do
+      put "/projects/#{project.id}", project: new_invalid_attributes
+      expect(Ninetails::Project.find(project.id).name).to eq project.name
+    end
+
+    it "should show errors if the new params are invalid" do
+      put "/projects/#{project.id}", project: new_invalid_attributes
+
+      expect(response).to_not be_success
+      expect(json["project"]["errors"]["name"]).not_to be_empty
+    end
+
+    it "should not create a new project" do
+      expect {
+        put "/projects/#{project.id}", project: new_valid_attributes
+      }.not_to change{ Ninetails::Project.count }
+    end
+  end
+
+end


### PR DESCRIPTION
This defines a basic projects structure where projects can have many pages and revisions. In the scope of a project, each page can have one head revision, making it possible to make a set of changes all related to the same context, which can then be published (to page.current_revision) when the project is published.
