### PR TITLE
Making it possible to publish projects

### DIFF
--- a/app/controllers/ninetails/projects_controller.rb
+++ b/app/controllers/ninetails/projects_controller.rb
@@ -1,7 +1,7 @@
 module Ninetails
   class ProjectsController < ApplicationController
 
-    before_action :find_project, only: [:update, :destroy]
+    before_action :find_project, only: [:update, :destroy, :publish]
 
     def index
       @projects = Project.all
@@ -28,6 +28,11 @@ module Ninetails
     def destroy
       @project.destroy
       head :no_content
+    end
+
+    def publish
+      @project.publish!
+      render :show
     end
 
     private

--- a/app/models/ninetails/page.rb
+++ b/app/models/ninetails/page.rb
@@ -20,5 +20,10 @@ module Ninetails
       end
     end
 
+    def set_current_revision(revision)
+      update_attributes current_revision: revision
+      self.revision = revision
+    end
+
   end
 end

--- a/app/models/ninetails/project.rb
+++ b/app/models/ninetails/project.rb
@@ -6,5 +6,13 @@ module Ninetails
 
     validates :name, presence: true
 
+    def publish!
+      project_pages.each do |project_page|
+        project_page.page.set_current_revision project_page.page_revision
+      end
+
+      update_attributes published: true
+    end
+
   end
 end

--- a/app/views/ninetails/projects/index.json.jbuilder
+++ b/app/views/ninetails/projects/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.projects @projects, :id, :name, :description
+json.projects @projects, :id, :name, :description, :published

--- a/app/views/ninetails/projects/show.json.jbuilder
+++ b/app/views/ninetails/projects/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.project do
-  json.call @project, :id, :name, :description
+  json.call @project, :id, :name, :description, :published
 
   if @project.errors.present?
     json.errors @project.errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Ninetails::Engine.routes.draw do
     root 'pages#index'
 
     resources :projects, only: [:create, :update, :index, :destroy] do
+      post :publish, on: :member
       resources :pages, only: [:show, :create, :index]
     end
 

--- a/db/migrate/20160303084056_add_published_to_projects.rb
+++ b/db/migrate/20160303084056_add_published_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPublishedToProjects < ActiveRecord::Migration
+  def change
+    add_column :ninetails_projects, :published, :boolean, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160121135155) do
+ActiveRecord::Schema.define(version: 20160303084056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,8 +58,9 @@ ActiveRecord::Schema.define(version: 20160121135155) do
   end
 
   create_table "ninetails_projects", force: :cascade do |t|
-    t.string "name"
-    t.string "description"
+    t.string  "name"
+    t.string  "description"
+    t.boolean "published",   default: false
   end
 
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -22,4 +22,24 @@ describe Ninetails::Project do
     expect(invalid_project.errors[:name]).to include "can't be blank"
   end
 
+  describe "publishing" do
+    it "should be unpublished by default" do
+      expect(project.published?).to be false
+    end
+
+    it "should call #set_current_revision on each page with the correct revision" do
+      project.project_pages.each do |project_page|
+        expect(project_page.page).to receive(:set_current_revision).with(project_page.page_revision)
+      end
+
+      project.publish!
+    end
+
+    it "should be published after calling #publish!" do
+      expect {
+        project.publish!
+      }.to change{ project.published? }.from(false).to(true)
+    end
+  end
+
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -13,13 +13,14 @@ describe "Projects API" do
       expect(json["projects"].size).to eq 5
     end
 
-    it "should include the id, name, and description for each project" do
+    it "should include the id, name, published, and description for each project" do
       get "/projects"
 
       json["projects"].each do |project|
         expect(project).to have_key "id"
         expect(project).to have_key "name"
         expect(project).to have_key "description"
+        expect(project).to have_key "published"
       end
     end
   end
@@ -84,6 +85,17 @@ describe "Projects API" do
       expect {
         delete "/projects/#{project.id}"
       }.to change{ Ninetails::Project.count }.by(-1)
+    end
+  end
+
+  describe "publishing projects" do
+    let(:project) { create :project }
+
+    it "should show that the project is published in the json" do
+      post "/projects/#{project.id}/publish"
+
+      expect(response).to be_success
+      expect(json["project"]["published"]).to be true
     end
   end
 


### PR DESCRIPTION
When publishing a project, each page's current_revision_id is set to the Ninetails::ProjectPage revision for the project. I've also added a project.published? boolean to make it easier to filter/display unpublished projects in the index.

@marreman 
