### PR TITLE
Variants

### DIFF
--- a/app/components/ninetails/section.rb
+++ b/app/components/ninetails/section.rb
@@ -44,6 +44,15 @@ module Ninetails
       @elements || []
     end
 
+    def self.has_variants(*variants)
+      @variants ||= []
+      @variants << variants
+    end
+
+    def self.variants
+      @variants.try(:flatten) || []
+    end
+
     def self.find_element(name)
       elements.find { |element| element.name == name.to_sym }
     end
@@ -54,6 +63,7 @@ module Ninetails
         type: self.class.name.demodulize,
         located_in: self.class.position,
         location_name: self.class.location_name,
+        variants: self.class.variants,
         elements: serialize_elements
       }
     end

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -32,7 +32,7 @@ module Ninetails
       self.revision = revisions.build message: params[:message], project_id: params[:project_id]
 
       params[:sections].each do |section_json|
-        revision.sections.build section_json.only(:name, :type, :elements)
+        revision.sections.build section_json.only(:name, :type, :elements, :variant)
       end
     end
 

--- a/app/views/ninetails/sections/_section.json.jbuilder
+++ b/app/views/ninetails/sections/_section.json.jbuilder
@@ -1,1 +1,1 @@
-json.call section, :id, :name, :type, :located_in, :location_name, :elements
+json.call section, :id, :name, :type, :located_in, :location_name, :variant, :elements

--- a/db/migrate/20160629103231_add_variant_to_content_section.rb
+++ b/db/migrate/20160629103231_add_variant_to_content_section.rb
@@ -1,0 +1,5 @@
+class AddVariantToContentSection < ActiveRecord::Migration
+  def change
+    add_column :ninetails_content_sections, :variant, :string
+  end
+end

--- a/lib/ninetails/seeds/section_builder.rb
+++ b/lib/ninetails/seeds/section_builder.rb
@@ -18,6 +18,8 @@ module Ninetails
       def method_missing(method, *args, &block)
         if element_definition(method).present?
           add_element_to_section method, args.first
+        elsif content_section.respond_to? "#{method}="
+          content_section.public_send "#{method}=", *args
         else
           raise "Unknown attribute #{method} on #{section_class}. Check your seeds!"
         end

--- a/spec/components/section_spec.rb
+++ b/spec/components/section_spec.rb
@@ -15,6 +15,17 @@ class ExampleSectionWithNoElements < Ninetails::Section
   name_as_location :example
 end
 
+class ExampleSectionWithVariants < Ninetails::Section
+  located_in :body
+  has_variants :light, :dark, :neon
+end
+
+class ExampleSectionWithMultipleVariants < Ninetails::Section
+  located_in :body
+  has_variants :light, :dark
+  has_variants :good, :evil
+end
+
 RSpec.describe Ninetails::Section do
 
   describe "creating a section from a file name" do
@@ -83,6 +94,7 @@ RSpec.describe Ninetails::Section do
   describe "structure" do
     let(:structure) { ExampleSection.new.serialize }
     let(:placeholder_structure) { ExamplePlaceholderSection.new.serialize }
+    let(:variants_structure) { ExampleSectionWithVariants.new.serialize }
 
     it "should have a type key which is the section class name" do
       expect(structure[:type]).to eq "ExampleSection"
@@ -108,6 +120,28 @@ RSpec.describe Ninetails::Section do
 
     it "should still have an elements key if the section has no elements" do
       expect(ExampleSectionWithNoElements.new.serialize[:elements]).to eq Hash.new
+    end
+
+    it "should include variants when they are defined" do
+      expect(variants_structure[:variants]).to eq [:light, :dark, :neon]
+    end
+
+    it "should include an empty set of variants when none are defined" do
+      expect(structure[:variants]).to eq []
+    end
+  end
+
+  describe "variants" do
+    it "should store a list of variants" do
+      expect(ExampleSectionWithVariants.variants).to eq [:light, :dark, :neon]
+    end
+
+    it "should allow multiple has_variants calls to store a list of variants" do
+      expect(ExampleSectionWithMultipleVariants.variants).to eq [:light, :dark, :good, :evil]
+    end
+
+    it "should have no variants by default" do
+      expect(ExampleSection.variants).to eq []
     end
   end
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160607135025) do
+ActiveRecord::Schema.define(version: 20160629103231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20160607135025) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.json     "tags"
+    t.string   "variant"
   end
 
   create_table "ninetails_project_containers", force: :cascade do |t|

--- a/spec/models/content_section_spec.rb
+++ b/spec/models/content_section_spec.rb
@@ -11,6 +11,11 @@ module Section
   class TestPlaceholderSection < Ninetails::Section
     name_as_location :body
   end
+
+  class TestSectionWithVariants < Ninetails::Section
+    located_in :body
+    has_variants :light, :dark
+  end
 end
 
 RSpec.describe Ninetails::ContentSection, type: :model do
@@ -160,7 +165,29 @@ RSpec.describe Ninetails::ContentSection, type: :model do
 
     it "should create a section instance" do
       section.deserialize
-      expect(section.section).to be_a Section::TestPlaceholderSection 
+      expect(section.section).to be_a Section::TestPlaceholderSection
+    end
+  end
+
+  describe "deserializing an empty section with a variant name" do
+    let(:valid_json) do
+      {
+        "name" => "",
+        "type" => "TestSectionWithVariants",
+        "variant" => "light"
+      }
+    end
+
+    let(:section) { Ninetails::ContentSection.new(valid_json) }
+
+    it "should create a section instance" do
+      section.deserialize
+      expect(section.section).to be_a Section::TestSectionWithVariants
+    end
+
+    it "should set the variant name" do
+      section.deserialize
+      expect(section.variant).to eq "light"
     end
   end
 

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -69,6 +69,17 @@ describe "Revisions API" do
       }
     end
 
+    let(:valid_revision_params_with_variant) do
+      {
+        "revision": {
+          "message": "",
+          "sections":[
+            document_head_section(variant: "extended")
+          ]
+        }
+      }
+    end
+
     describe "with valid sections and a project id" do
       it "should create a revision with the project id" do
         expect {
@@ -119,6 +130,22 @@ describe "Revisions API" do
       it "should have created the correct number of sections" do
         post "/pages/#{page.id}/revisions", valid_revision_params
         expect(page.revisions.last.sections.size).to eq 1
+      end
+    end
+
+    describe "with valid sections and a variant" do
+      it "should create a revision" do
+        expect {
+          post "/pages/#{page.id}/revisions", valid_revision_params_with_variant
+        }.to change { page.revisions.count }.by(1)
+
+        expect(response).to be_success
+        expect(json["container"]["revisionId"]).to_not be_nil
+      end
+
+      it "should have stored the variant" do
+        post "/pages/#{page.id}/revisions", valid_revision_params_with_variant
+        expect(page.revisions.last.sections.first.variant).to eq "extended"
       end
     end
 

--- a/spec/support/section_helpers.rb
+++ b/spec/support/section_helpers.rb
@@ -1,9 +1,10 @@
 module SectionHelpers
 
-  def document_head_section(title: "Title text", description: "Description text")
+  def document_head_section(title: "Title text", description: "Description text", variant: nil)
     {
       "name": "",
       "type": "DocumentHead",
+      "variant": variant,
       "elements": {
         "title": {
           "type": "Text",


### PR DESCRIPTION
This introduces a super simple way of storing variants on Sections. The idea being you could have a section which, for example, could have a light version and a dark version. When defining the section, you can now do this:

``` ruby
module Section
  class SomeSection < Ninetails::Section
    located_in :body
    has_variants :light, :dark
  end
end
```

Then, when creating the section, you can choose one of them and it'll be returned when fetching the section, as you'd expect.

In the future I can imagine we'd want more control and the ability to choose multiple variants of a section, but for now, this gives us a little more freedom when creating sections.

@marreman thoughts?
