### PR TITLE
Fix improper save

### DIFF
--- a/app/components/ninetails/element.rb
+++ b/app/components/ninetails/element.rb
@@ -7,8 +7,9 @@ module Ninetails
     end
 
     def deserialize(input)
+      snake_case_input = input.convert_keys
       properties_instances.collect do |property|
-        property.serialized_values = input[property.name.to_s]
+        property.serialized_values = snake_case_input[property.name.to_s]
       end
     end
 

--- a/config/initializers/json_param_key_transform.rb
+++ b/config/initializers/json_param_key_transform.rb
@@ -1,0 +1,8 @@
+ActionDispatch::Request.parameter_parsers[:json] = -> (raw_post) {
+  # Modified from action_dispatch/http/parameters.rb
+  data = ActiveSupport::JSON.decode(raw_post)
+  data = {:_json => data} unless data.is_a?(Hash)
+
+  # Transform camelCase param keys to snake_case:
+  data.deep_transform_keys!(&:underscore)
+}

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -205,6 +205,7 @@ describe "Revisions API" do
 
       expect(response).to be_success
       expect(json["container"]["revisionId"]).to_not be_nil
+      expect(json["container"]["sections"][0]["elements"]["backgroundImage"]).to_not be_nil
     end
 
   end


### PR DESCRIPTION
@idlefingers I managed to fix the symptoms of the problem I was talking to you about earlier. We where losing some properties and sometimes whole elements when saving. It seems we are not converting the keys from camelCase to snake_case properly.

The `json_param_key_transform.rb` initializer fixed some of the issues but element deserialization happened twice. Once with snake_case and then once again but this with camelCase keys. Therefore I blindly convert the element input as seen in `element.rb`

Any ideas?
