### PR TITLE
Fix revision creation

### DIFF
--- a/app/components/ninetails/element.rb
+++ b/app/components/ninetails/element.rb
@@ -13,7 +13,7 @@ module Ninetails
     end
 
     def properties_structure
-      generate_structure.convert_keys(:to_api).with_indifferent_access
+      generate_structure.with_indifferent_access
     end
 
     # Validate each property_type's property.

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -28,7 +28,7 @@ module Ninetails
     end
 
     def build_revision_from_params(params)
-      params = params.transform_keys { |k| k.underscore }
+      params = params.to_h.convert_keys.with_indifferent_access
       self.revision = revisions.build message: params[:message], project_id: params[:project_id]
 
       params[:sections].each do |section_json|

--- a/spec/dummy/app/components/element/long_name_element.rb
+++ b/spec/dummy/app/components/element/long_name_element.rb
@@ -1,0 +1,7 @@
+module Element
+  class LongNameElement < Ninetails::Element
+
+    property :long_name_property, Property::LongNameProperty
+
+  end
+end

--- a/spec/dummy/app/components/property/long_name_property.rb
+++ b/spec/dummy/app/components/property/long_name_property.rb
@@ -1,0 +1,7 @@
+module Property
+  class LongNameProperty < Ninetails::Property
+
+    property :long_text_string, String
+
+  end
+end

--- a/spec/dummy/app/components/section/long_name_section.rb
+++ b/spec/dummy/app/components/section/long_name_section.rb
@@ -1,0 +1,9 @@
+module Section
+  class LongNameSection < Ninetails::Section
+
+    located_in :body
+
+    has_element :long_name_element, Element::LongNameElement
+
+  end
+end

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -174,6 +174,13 @@ describe "Revisions API" do
   end
 
   describe "handling hash keys in camelcase" do
+    before do
+      Ninetails::Config.key_style = :camelcase
+    end
+
+    after do
+      Ninetails::Config.key_style = :underscore
+    end
 
     let(:camelcased_revision) do
       {

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -189,13 +189,12 @@ describe "Revisions API" do
           sections: [
             {
               "name": "",
-              "type": "MinimalBillboard",
+              "type": "LongNameSection",
               "elements": {
-                "backgroundImage": {
-                  "type": "Figure",
-                  "image": {
-                    "src": "/foobar.jpg",
-                    "alt": "Hello world"
+                "longNameElement": {
+                  "type": "LongNameElement",
+                  "longNameProperty": {
+                    "longTextString": "foo"
                   }
                 }
               }
@@ -212,7 +211,7 @@ describe "Revisions API" do
 
       expect(response).to be_success
       expect(json["container"]["revisionId"]).to_not be_nil
-      expect(json["container"]["sections"][0]["elements"]["backgroundImage"]).to_not be_nil
+      expect(json["container"]["sections"][0]["elements"]["longNameElement"]["longNameProperty"]["longTextString"]).to_not be_nil
     end
 
   end

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -205,6 +205,7 @@ describe "Revisions API" do
 
       expect(response).to be_success
       expect(json["container"]["revisionId"]).to_not be_nil
+      expect(json["container"]["sections"][0]["elements"]["backgroundImage"]).to_not be_nil
     end
 
   end


### PR DESCRIPTION
@idlefingers I foundz better solution. It appears `transform_keys` only works on a single instance of `ActionController::Parameters` and we are working on nested instances. There's something called `deep_transform_keys` that will be deprecated:

> DEPRECATION WARNING: Method deep_transform_keys is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0/classes/ActionController/Parameters.html

So I resorted to converting it to a hash using [`to_h`](http://api.rubyonrails.org/v5.0.0/classes/ActionController/Parameters.html#method-i-to_h) and then doing the convertion of keys.
