### PR TITLE
Fixing ProjectContainer revision validation bug

### DIFF
--- a/app/models/ninetails/project_container.rb
+++ b/app/models/ninetails/project_container.rb
@@ -11,7 +11,7 @@ module Ninetails
 
     validates :revision, {
       uniqueness: {
-        scope: :project,
+        scope: [:project, :container],
         message: "has already been set for this container in the project"
       }
     }

--- a/spec/factories/project_containers.rb
+++ b/spec/factories/project_containers.rb
@@ -4,9 +4,11 @@ FactoryGirl.define do
     project
     container
 
-    after :create do |project_container, evaluator|
-      revision = create :revision, container: project_container.container, project: project_container.project
-      project_container.update revision: revision
+    trait :with_revision do
+      after :create do |project_container, evaluator|
+        revision = create :revision, container: project_container.container, project: project_container.project
+        project_container.update revision: revision
+      end
     end
   end
 

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ninetails::Container, type: :model do
       @page = create :page, :with_revisions
       @layout = create :layout
       @project = create :project
-      @project_container = create :project_container, project: @project, container: @page
+      @project_container = create :project_container, :with_revision, project: @project, container: @page
     end
 
     it "should find a page by id" do

--- a/spec/models/project_container_spec.rb
+++ b/spec/models/project_container_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Ninetails::ProjectContainer do
 
-  let(:existing_container) { create :project_container }
+  let(:existing_container) { create :project_container, :with_revision }
 
   it "should require a project" do
     project_container = build :project_container, project: nil
@@ -24,7 +24,6 @@ describe Ninetails::ProjectContainer do
   describe "validating uniqueness of the container revision" do
     let(:duplicate_revision) { build :project_container, revision: existing_container.revision }
     let(:duplicate_container) { build :project_container, container: existing_container.container }
-    let(:duplicate_revsion_in_project) { build :project_container, revision: existing_container.revision, project: existing_container.project }
     let(:duplicate_container_in_project) { build :project_container, container: existing_container.container, project: existing_container.project }
 
     it "should allow the same revision to be referenced in multiple projects" do
@@ -35,14 +34,15 @@ describe Ninetails::ProjectContainer do
       expect(duplicate_container.valid?).to be true
     end
 
-    it "should not allow the same container to have multiple revisions in the project" do
-      expect(duplicate_revsion_in_project.valid?).to be false
-      expect(duplicate_revsion_in_project.errors[:revision]).to include "has already been set for this container in the project"
-    end
-
-    it "should not allow the same container to be used in the same project" do
+    it "should not allow the same container to be used multiple times in the same project" do
       expect(duplicate_container_in_project.valid?).to be false
       expect(duplicate_container_in_project.errors[:container]).to include "is already used in this project"
+    end
+
+    it "should not cause problems when the revision is nil and the project has multiple containers" do
+      first_container = create :project_container, project: existing_container.project, revision: nil
+      second_container = create :project_container, project: existing_container.project, revision: nil
+      expect(second_container.valid?).to be true
     end
   end
 

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -103,7 +103,7 @@ describe "Revisions API" do
       end
 
       it "should modify an existing ProjectContainer entry if one exists for this page in the project" do
-        project_container = create :project_container, container: page, project: project
+        project_container = create :project_container, :with_revision, container: page, project: project
 
         expect {
           post "/pages/#{page.id}/revisions", params: valid_revision_params_with_project


### PR DESCRIPTION
When the revision was nil, because the validation didn't use the container when checking uniqueness, only one ProjectContainer could be created per project.

@marreman 🍩 
