### PR TITLE
Changing container to current_revision relationship to be belongs_to

### DIFF
--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -3,7 +3,7 @@ module Ninetails
 
     has_many :revisions
     has_many :project_containers
-    has_one :current_revision, class_name: "Revision"
+    belongs_to :current_revision, class_name: "Revision"
 
     scope :pages, -> { where type: 'Ninetails::Page' }
     scope :layouts, -> { where type: 'Ninetails::Layout' }

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -15,9 +15,7 @@ FactoryGirl.define do
       end
 
       after :create do |container, evaluator|
-        # -1 because the page is created with a 'current_revision', so when you say revisions_count: 10,
-        # you'll only end up with 10 revisions instead of 11..
-        create_list :revision, evaluator.revisions_count - 1, container: container
+        create_list :revision, evaluator.revisions_count, container: container
       end
     end
 

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Ninetails::Container, type: :model do
 
   it { should have_many(:revisions) }
   it { should have_many(:project_containers) }
-  it { should have_one(:current_revision) }
+  it { should belong_to(:current_revision) }
 
   it { should validate_presence_of(:locale) }
 


### PR DESCRIPTION
Basically when this was `has_one`, the container never stored the `current_revision_id`, so the current revision ended up being very weird when you published a project. `belongs_to` feels weird, but it's correct as it will now use the key in the containers table to select the revision.

@marreman 🍩 
