### PR TITLE
Better revisions

### DIFF
--- a/app/controllers/ninetails/containers_controller.rb
+++ b/app/controllers/ninetails/containers_controller.rb
@@ -34,7 +34,7 @@ module Ninetails
     private
 
     def container_params
-      params.require(:container).permit(:url, :name, :locale, :layout_id)
+      params.require(:container).permit(:name, :locale, :layout_id)
     end
 
     def container_class

--- a/app/controllers/ninetails/containers_controller.rb
+++ b/app/controllers/ninetails/containers_controller.rb
@@ -3,9 +3,9 @@ module Ninetails
 
     def index
       if project.present?
-        @containers = project.public_send params[:type]
+        @project_containers = project.project_containers.of_type container_class.name
       else
-        @containers = container_class.all
+        @containers = container_class.all.includes :current_revision
       end
     end
 

--- a/app/controllers/ninetails/containers_controller.rb
+++ b/app/controllers/ninetails/containers_controller.rb
@@ -3,7 +3,7 @@ module Ninetails
 
     def index
       if project.present?
-        @project_containers = project.project_containers.of_type container_class.name
+        @containers = project.project_containers.of_type container_class.name
       else
         @containers = container_class.all.includes :current_revision
       end
@@ -24,7 +24,7 @@ module Ninetails
         render :show, status: :bad_request
       end
     end
-    
+
     def destroy
       container_class.find(params[:id]).destroy
 

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -15,11 +15,12 @@ module Ninetails
 
     def self.find_and_load_revision(params, project = nil)
       if params[:id].to_s =~ /^\d+$/
-        container = find params[:id]
+        selector = where id: params[:id]
       else
-        container = joins(:revisions).merge(Ninetails::Revision.where(url: params[:id])).first!
+        selector = joins(:revisions).merge Ninetails::Revision.where(url: params[:id])
       end
 
+      container = selector.includes(:current_revision).first!
       container.load_revision_directly_or_from_project params[:revision_id], project
       container
     end

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -17,7 +17,7 @@ module Ninetails
       if params[:id].to_s =~ /^\d+$/
         container = find params[:id]
       else
-        container = find_by_url! params[:id]
+        container = joins(:revisions).merge(Ninetails::Revision.where(url: params[:id])).first!
       end
 
       container.load_revision_directly_or_from_project params[:revision_id], project
@@ -30,7 +30,11 @@ module Ninetails
 
     def build_revision_from_params(params)
       params = params.to_h.convert_keys.with_indifferent_access
-      self.revision = revisions.build message: params[:message], project_id: params[:project_id]
+      self.revision = revisions.build(
+        message: params[:message],
+        project_id: params[:project_id],
+        url: params[:url]
+      )
 
       params[:sections].each do |section_json|
         revision.sections.build section_json.slice(:name, :type, :elements, :variant)

--- a/app/models/ninetails/page.rb
+++ b/app/models/ninetails/page.rb
@@ -1,7 +1,5 @@
 module Ninetails
   class Page < Container
     belongs_to :layout
-
-    validates :url, presence: true, uniqueness: { case_sensitive: false }
   end
 end

--- a/app/models/ninetails/project_container.rb
+++ b/app/models/ninetails/project_container.rb
@@ -24,5 +24,11 @@ module Ninetails
       }
     }
 
+    scope :of_type, -> type do
+      includes(:revision, :container).
+      joins(:container).
+      merge Container.where(type: type)
+    end
+
   end
 end

--- a/app/models/ninetails/project_container.rb
+++ b/app/models/ninetails/project_container.rb
@@ -5,6 +5,8 @@ module Ninetails
     belongs_to :revision
     belongs_to :project
 
+    delegate :name, :locale, :type, :current_revision, to: :container
+
     validates :project, {
       presence: true
     }

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -6,13 +6,7 @@ module Ninetails
     has_many :revision_sections
     has_many :sections, -> { order :created_at }, through: :revision_sections
 
-    validate :sections_are_all_valid
-    # validates :url, uniqueness: {
-    #   case_sensitive: false,
-    #   scope: :container,
-    #   conditions: -> { binding.pry }
-    # }, if: :requires_unique_url?
-    validate :url_is_unique
+    validate :sections_are_all_valid, :url_is_unique
 
     after_create :update_project_container, if: -> { project.present? }
 

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -7,7 +7,7 @@ module Ninetails
     has_many :sections, -> { order :created_at }, through: :revision_sections
 
     validate :sections_are_all_valid
-    validates :url, presence: true, uniqueness: { case_sensitive: false }, if: -> { container.is_a? Ninetails::Page }
+    validates :url, uniqueness: { case_sensitive: false, scope: :container }, if: :requires_unique_url?
 
     after_create :update_project_container, if: -> { project.present? }
 
@@ -27,6 +27,10 @@ module Ninetails
       project_container = ProjectContainer.find_or_initialize_by project_id: project.id, container_id: container.id
       project_container.revision = self
       project_container.save
+    end
+    
+    def requires_unique_url?
+      container.is_a?(Ninetails::Page) && url.present?
     end
 
   end

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -7,7 +7,12 @@ module Ninetails
     has_many :sections, -> { order :created_at }, through: :revision_sections
 
     validate :sections_are_all_valid
-    validates :url, uniqueness: { case_sensitive: false, scope: :container }, if: :requires_unique_url?
+    # validates :url, uniqueness: {
+    #   case_sensitive: false,
+    #   scope: :container,
+    #   conditions: -> { binding.pry }
+    # }, if: :requires_unique_url?
+    validate :url_is_unique
 
     after_create :update_project_container, if: -> { project.present? }
 
@@ -30,7 +35,13 @@ module Ninetails
     end
     
     def requires_unique_url?
-      container.is_a?(Ninetails::Page) && url.present?
+      container.is_a?(Page) && url.present?
+    end
+    
+    def url_is_unique
+      if container.is_a?(Page) && url.present? && Revision.where(url: url).where.not(container: container).exists?
+        errors.add :url, "is already in use"
+      end
     end
 
   end

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -7,6 +7,7 @@ module Ninetails
     has_many :sections, -> { order :created_at }, through: :revision_sections
 
     validate :sections_are_all_valid
+    validates :url, presence: true, uniqueness: { case_sensitive: false }, if: -> { container.is_a? Ninetails::Page }
 
     after_create :update_project_container, if: -> { project.present? }
 

--- a/app/views/ninetails/containers/_container.json.jbuilder
+++ b/app/views/ninetails/containers/_container.json.jbuilder
@@ -3,19 +3,17 @@ json.container do
   json.revision_id container.try(:revision).try(:id)
   json.type container.type.demodulize
 
-  if container.is_a? Ninetails::Page
-    json.url container.url
-
-    if container.layout.present?
-      json.layout do
-        json.partial! "/ninetails/containers/container", container: container.layout
-      end
+  if container.try(:layout).present?
+    json.layout do
+      json.partial! "/ninetails/containers/container", container: container.layout
     end
   end
 
   if container.revision.present?
+    json.published container.revision.published
     json.sections container.revision.sections, partial: "/ninetails/sections/section", as: :section
   else
+    json.published false
     json.sections []
   end
 

--- a/app/views/ninetails/containers/_container.json.jbuilder
+++ b/app/views/ninetails/containers/_container.json.jbuilder
@@ -1,6 +1,5 @@
 json.container do
   json.call container, :id, :name, :locale
-  json.revision_id container.try(:revision).try(:id)
   json.type container.type.demodulize
 
   if container.try(:layout).present?
@@ -9,12 +8,14 @@ json.container do
     end
   end
 
-  if container.revision.present?
-    json.published container.revision.published
-    json.sections container.revision.sections, partial: "/ninetails/sections/section", as: :section
-  else
-    json.published false
-    json.sections []
+  json.current_revision do
+    json.partial! "/ninetails/revisions/revision", revision: container.current_revision, container_type: container.class
+  end
+
+  if container.revision != container.current_revision
+    json.revision do
+      json.partial! "/ninetails/revisions/revision", revision: container.revision, container_type: container.class
+    end
   end
 
   if container.errors.present?

--- a/app/views/ninetails/containers/index.json.jbuilder
+++ b/app/views/ninetails/containers/index.json.jbuilder
@@ -1,9 +1,4 @@
 json.containers @containers do |container|
   json.call container, :id, :name, :locale
-
-  if container.is_a? Ninetails::Page
-    json.url container.url
-  end
-
   json.type container.type.demodulize
 end

--- a/app/views/ninetails/containers/index.json.jbuilder
+++ b/app/views/ninetails/containers/index.json.jbuilder
@@ -1,17 +1,22 @@
-if @project_containers.present?
-  json.containers @project_containers do |project_container|
-    json.call project_container.container, :id, :name, :locale
-    json.call project_container.revision, :url, :published
-    json.type project_container.container.type.demodulize
+json.containers @containers do |container|
+  if container.is_a? Ninetails::ProjectContainer
+    json.call container.container, :id
+  else
+    json.call container, :id
   end
-else
-  json.containers @containers do |container|
-    json.call container, :id, :name, :locale
-    
-    if container.current_revision.present?
+
+  json.call container, :name, :locale
+  json.type container.type.demodulize
+
+  if container.current_revision.present?
+    json.current_revision do
       json.call container.current_revision, :url, :published
     end
+  end
 
-    json.type container.type.demodulize
+  if container.revision.present?
+    json.revision do
+      json.call container.revision, :url, :published
+    end
   end
 end

--- a/app/views/ninetails/containers/index.json.jbuilder
+++ b/app/views/ninetails/containers/index.json.jbuilder
@@ -1,4 +1,17 @@
-json.containers @containers do |container|
-  json.call container, :id, :name, :locale
-  json.type container.type.demodulize
+if @project_containers.present?
+  json.containers @project_containers do |project_container|
+    json.call project_container.container, :id, :name, :locale
+    json.call project_container.revision, :url, :published
+    json.type project_container.container.type.demodulize
+  end
+else
+  json.containers @containers do |container|
+    json.call container, :id, :name, :locale
+    
+    if container.current_revision.present?
+      json.call container.current_revision, :url, :published
+    end
+
+    json.type container.type.demodulize
+  end
 end

--- a/app/views/ninetails/revisions/_revision.json.jbuilder
+++ b/app/views/ninetails/revisions/_revision.json.jbuilder
@@ -1,0 +1,10 @@
+if revision.present?
+  if container_type.present? && container_type == Ninetails::Page
+    json.call revision, :id, :url, :published
+  else
+    json.call revision, :id
+  end
+  json.sections revision.sections, partial: "/ninetails/sections/section", as: :section
+else
+  json.sections []
+end

--- a/db/migrate/20161028094727_add_url_and_published_to_revision.rb
+++ b/db/migrate/20161028094727_add_url_and_published_to_revision.rb
@@ -1,0 +1,6 @@
+class AddUrlAndPublishedToRevision < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ninetails_revisions, :url, :string
+    add_column :ninetails_revisions, :published, :boolean, default: false
+  end
+end

--- a/db/migrate/20161028102730_remove_url_from_containers.rb
+++ b/db/migrate/20161028102730_remove_url_from_containers.rb
@@ -1,5 +1,15 @@
 class RemoveUrlFromContainers < ActiveRecord::Migration[5.0]
-  def change
-    remove_column :ninetails_containers, :url, :string
+  def up
+    Ninetails::Page.with_deleted.all.each do |page|
+      page.revisions.each do |revision|
+        revision.update_attributes url: page.url unless revision.url.present?
+      end
+    end
+
+    remove_column :ninetails_containers, :url
+  end
+
+  def down
+    add_column :ninetails_containers, :url, :string
   end
 end

--- a/db/migrate/20161028102730_remove_url_from_containers.rb
+++ b/db/migrate/20161028102730_remove_url_from_containers.rb
@@ -1,0 +1,5 @@
+class RemoveUrlFromContainers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :ninetails_containers, :url, :string
+  end
+end

--- a/lib/ninetails/seeds/generator.rb
+++ b/lib/ninetails/seeds/generator.rb
@@ -34,6 +34,7 @@ module Ninetails
         c.container.create_current_revision
         block.call c
         c.container.save!
+        c.container.current_revision.update_attributes container_id: c.container.id
         c.container
       end
 
@@ -55,6 +56,10 @@ module Ninetails
         else
           container.layout = Ninetails::Layout.find layout
         end
+      end
+      
+      def url(url)
+        container.current_revision.url = url
       end
 
       def method_missing(name, *args, &block)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161025133925) do
+ActiveRecord::Schema.define(version: 20161028102730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 20161025133925) do
   create_table "ninetails_containers", force: :cascade do |t|
     t.integer  "current_revision_id"
     t.string   "name"
-    t.string   "url"
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
     t.string   "type",                default: "Ninetails::Page"
@@ -64,10 +63,12 @@ ActiveRecord::Schema.define(version: 20161025133925) do
 
   create_table "ninetails_revisions", force: :cascade do |t|
     t.integer  "container_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "message"
     t.integer  "project_id"
+    t.string   "url"
+    t.boolean  "published",    default: false
     t.index ["container_id"], name: "index_ninetails_revisions_on_container_id", using: :btree
     t.index ["project_id"], name: "index_ninetails_revisions_on_project_id", using: :btree
   end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -1,27 +1,27 @@
 FactoryGirl.define do
 
-  sequence :url do |n|
-    "/foo/#{n}"
-  end
-
   factory :container, class: Ninetails::Container do
     association :current_revision, factory: :revision
     locale "en_US"
-    url
+    
+    # The current_revision association is a slightly strange additon to a 
+    # has_many relationship in FactoryGirl's world, which seems to be causing issues
+    # with newly created "current_revision" revisions not having a container_id. So this
+    # manually fixes that.
+    after :create do |container, _|
+      if container.current_revision.present? && container.current_revision.container_id.nil?
+        container.current_revision.update_attributes container_id: container.id
+      end
+    end
 
     trait :with_revisions do
       transient do
         revisions_count 5
       end
 
+      # -1 because the container is created with a default "current_revision"
       after :create do |container, evaluator|
-        create_list :revision, evaluator.revisions_count, container: container
-      end
-    end
-
-    trait :with_a_revision do
-      after :create do |container, _|
-        create :revision, container: container
+        create_list :revision, evaluator.revisions_count - 1, container: container
       end
     end
   end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -1,8 +1,13 @@
 FactoryGirl.define do
 
+  sequence :url do |n|
+    "/foo/#{n}"
+  end
+
   # Default page revision factory has no sections... They're complicated to mock and make valid
   # and all the tests which currently use them, build them manually anyway...
   factory :revision, class: Ninetails::Revision do
+    url
   end
 
 end

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Ninetails::Container, type: :model do
     end
 
     it "should find a page by url" do
-      expect(Ninetails::Container.find_and_load_revision(id: @page.url)).to eq @page
+      expect(Ninetails::Container.find_and_load_revision(id: @page.current_revision.url)).to eq @page
     end
 
     it "should find a layout by id" do
@@ -75,6 +75,20 @@ RSpec.describe Ninetails::Container, type: :model do
 
     it "should return the container current_revision if no custom revision is set" do
       expect(@container.revision).to eq @container.revisions.last
+    end
+  end
+
+  describe "#set_current_revision" do
+    before do
+      @old_revision = create :revision
+      @container = create :page, revision: @old_revision
+      @new_revision = create :revision
+    end
+    
+    it "updates the revision id" do
+      expect {
+        @container.set_current_revision(@new_revision)
+      }.to change{ @container.revision }.from(@old_revision).to(@new_revision)
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,12 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe Ninetails::Page, type: :model do
-
-  describe "validations" do
-    subject { create :page }
-
-    it { should validate_presence_of(:url) }
-    it { should validate_uniqueness_of(:url).case_insensitive }
-  end
-
 end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -35,10 +35,16 @@ RSpec.describe Ninetails::Revision, type: :model do
     end
     
     describe "when the url is present" do
-      it "requires a unique url for Page revisions" do
+      it "doesn't allow the url to be used for different containers" do
+        revision = Ninetails::Revision.new container: create(:page), url: "/foo"
+        revision.valid?
+        expect(revision.errors[:url]).to eq ["is already in use"]
+      end
+      
+      it "allows the same url to be used for the same container multiple times" do
         revision = Ninetails::Revision.new container: @page, url: "/foo"
         revision.valid?
-        expect(revision.errors[:url]).to eq ["has already been taken"]
+        expect(revision.errors[:url]).to eq []
       end
     end
   end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -11,16 +11,36 @@ RSpec.describe Ninetails::Revision, type: :model do
     expect(Ninetails::Revision.new.published).to eq false
   end
 
-  describe "when the container is a Page" do
-    subject  { create :revision, container: create(:page) }
+  describe "validating urls" do
+    before do
+      # Seed with some things to check uniqueness against
+      @page = create :page
+      @layout = create :layout
+      create :revision, container: @page, url: nil
+      create :revision, container: @page, url: "/foo"
+    end
     
-    it { should validate_presence_of(:url) }
-  end
-  
-  describe "when the container is a Layout" do
-    subject  { create :revision, container: create(:layout) }
-
-    it { should_not validate_presence_of(:url) }
+    describe "when the url is blank" do
+      it "doesn't require a url for Layout revisions" do
+        revision = Ninetails::Revision.new container: @layout, url: nil
+        revision.valid?
+        expect(revision.errors[:url]).to eq []
+      end
+      
+      it "doesn't require a url for Page revisions" do
+        revision = Ninetails::Revision.new container: @page, url: nil
+        revision.valid?
+        expect(revision.errors[:url]).to eq []
+      end
+    end
+    
+    describe "when the url is present" do
+      it "requires a unique url for Page revisions" do
+        revision = Ninetails::Revision.new container: @page, url: "/foo"
+        revision.valid?
+        expect(revision.errors[:url]).to eq ["has already been taken"]
+      end
+    end
   end
 
 end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -6,7 +6,21 @@ RSpec.describe Ninetails::Revision, type: :model do
   it { should belong_to(:project) }
   it { should have_many(:revision_sections) }
   it { should have_many(:sections).order(:created_at) }
+  
+  it "should not be published by default" do
+    expect(Ninetails::Revision.new.published).to eq false
+  end
 
-  # TODO: Write missing tests!
+  describe "when the container is a Page" do
+    subject  { create :revision, container: create(:page) }
+    
+    it { should validate_presence_of(:url) }
+  end
+  
+  describe "when the container is a Layout" do
+    subject  { create :revision, container: create(:layout) }
+
+    it { should_not validate_presence_of(:url) }
+  end
 
 end

--- a/spec/requests/containers_spec.rb
+++ b/spec/requests/containers_spec.rb
@@ -32,12 +32,6 @@ describe "Pages API" do
         json["containers"].each do |container|
           expect(container).to have_key "id"
           expect(container).to have_key "locale"
-
-          if container_type == :page
-            expect(container).to have_key "url"
-          else
-            expect(container).not_to have_key "url"
-          end
         end
       end
 
@@ -84,6 +78,10 @@ describe "Pages API" do
               expect(json["container"]["layout"]["container"]["id"]).to eq @layout.id
               expect(json["container"]["layout"]["container"]["type"]).to eq "Layout"
             end
+          end
+          
+          it "should include the revision's published attribute" do
+            expect(json["container"]["published"]).to eq container.current_revision.published
           end
         end
 
@@ -182,17 +180,6 @@ describe "Pages API" do
         {
           container: {
             name: "A new container",
-            url: "/foobar",
-            locale: "en_US"
-          }
-        }
-      end
-
-      let(:existing_page_url_params) do
-        {
-          container: {
-            name: "An existing container",
-            url: @page.url,
             locale: "en_US"
           }
         }
@@ -201,8 +188,7 @@ describe "Pages API" do
       let(:page_with_no_locale_params) do
         {
           container: {
-            name: "A container",
-            url: "/no-locale"
+            name: "A container"
           }
         }
       end
@@ -211,15 +197,6 @@ describe "Pages API" do
         expect {
           post url, params: valid_container_params
         }.to change{ container_class.count }.by(1)
-      end
-
-      if container_type == :page
-        it "should show errors if the url is taken" do
-          post url, params: existing_page_url_params
-
-          expect(response).to_not be_success
-          expect(json["container"]["errors"]["url"]).not_to be_empty
-        end
       end
 
       it "should require a locale" do

--- a/spec/requests/containers_spec.rb
+++ b/spec/requests/containers_spec.rb
@@ -32,6 +32,9 @@ describe "Pages API" do
         json["containers"].each do |container|
           expect(container).to have_key "id"
           expect(container).to have_key "locale"
+          expect(container).to have_key "url"
+          expect(container).to have_key "name"
+          expect(container).to have_key "published"
         end
       end
 

--- a/spec/requests/containers_spec.rb
+++ b/spec/requests/containers_spec.rb
@@ -76,7 +76,7 @@ describe "Pages API" do
           end
 
           it "should return the current revision of a page" do
-            expect(json["container"]["revisionId"]).to eq container.current_revision.id
+            expect(json["container"]["currentRevision"]["id"]).to eq container.current_revision.id
           end
 
           it "should return a container with type #{container_class}" do
@@ -88,10 +88,26 @@ describe "Pages API" do
               expect(json["container"]["layout"]["container"]["id"]).to eq @layout.id
               expect(json["container"]["layout"]["container"]["type"]).to eq "Layout"
             end
-          end
 
-          it "should include the revision's published attribute" do
-            expect(json["container"]["published"]).to eq container.current_revision.published
+            it "should include the revision's published attribute" do
+              expect(json["container"]["currentRevision"]["published"]).to eq container.current_revision.published
+            end
+
+            it "should include the revision's url attribute" do
+              expect(json["container"]["currentRevision"]["url"]).to eq container.current_revision.url
+            end
+          else
+            it "should not include a layout key" do
+              expect(json["container"]).not_to have_key "layout"
+            end
+
+            it "should not include a published attribute" do
+              expect(json["container"]["currentRevision"]).not_to have_key "published"
+            end
+
+            it "should not include a url attribute" do
+              expect(json["container"]["currentRevision"]).not_to have_key "url"
+            end
           end
         end
 
@@ -166,7 +182,7 @@ describe "Pages API" do
 
         it "should use the current project container to fetch the latest revision" do
           get "#{url}/#{project_container.container_id}"
-          expect(json["container"]["revisionId"]).to eq project_container.revision_id
+          expect(json["container"]["revision"]["id"]).to eq project_container.revision_id
         end
       end
 
@@ -236,12 +252,12 @@ describe "Pages API" do
 
       it "should have a blank revision id" do
         post url, params: valid_container_params
-        expect(json["container"]["revisionId"]).to be_nil
+        expect(json["container"]["currentRevision"]["id"]).to be_nil
       end
 
       it "should have an empty sections array" do
         post url, params: valid_container_params
-        expect(json["container"]["sections"]).to eq []
+        expect(json["container"]["currentRevision"]["sections"]).to eq []
       end
 
       it "should create a project container if in the project scope" do
@@ -265,7 +281,7 @@ describe "Pages API" do
           get url
 
           expect(response).to be_success
-          expect(json["container"]["revisionId"]).to eq container.current_revision.id
+          expect(json["container"]["currentRevision"]["id"]).to eq container.current_revision.id
         end
 
         it "should include the container locale" do
@@ -299,8 +315,9 @@ describe "Pages API" do
           get "#{url}?revision_id=#{new_revision.id}"
 
           expect(response).to be_success
-          expect(json["container"]["revisionId"]).to eq new_revision.id
-          expect(json["container"]["revisionId"]).not_to eq container.current_revision.id
+          expect(json["container"]["revision"]["id"]).not_to eq json["container"]["currentRevision"]["id"]
+          expect(json["container"]["revision"]["id"]).to eq new_revision.id
+          expect(json["container"]["revision"]["id"]).not_to eq container.current_revision.id
         end
 
         it "should return the specified revision of the container when using the id to fetch the container" do
@@ -310,8 +327,9 @@ describe "Pages API" do
           get "#{url}?revision_id=#{new_revision.id}"
 
           expect(response).to be_success
-          expect(json["container"]["revisionId"]).to eq new_revision.id
-          expect(json["container"]["revisionId"]).not_to eq container.current_revision.id
+          expect(json["container"]["revision"]["id"]).not_to eq json["container"]["currentRevision"]["id"]
+          expect(json["container"]["revision"]["id"]).to eq new_revision.id
+          expect(json["container"]["revision"]["id"]).not_to eq container.current_revision.id
         end
       end
 

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -23,22 +23,25 @@ describe "Revisions API" do
   end
 
   describe "creating a revision" do
+    
     let(:valid_revision_params) do
       {
-        "revision": {
-          "message": "",
-          "sections":[
+        revision: {
+          url: build(:revision).url,
+          sections: [
             document_head_section
           ]
         }
       }
     end
 
+    # TODO - test dupe url
+
     let(:valid_revision_params_with_extra_keys) do
       {
-        "revision": {
-          "message": "",
-          "sections":[
+        revision: {
+          url: build(:revision).url,
+          sections: [
             document_head_section.merge({ "located_in" => "body", "location_name" => "foobar" })
           ]
         }
@@ -47,9 +50,8 @@ describe "Revisions API" do
 
     let(:invalid_revision_params) do
       {
-        "revision": {
-          "message": "",
-          "sections":[
+        revision: {
+          sections: [
             document_head_section(title: "", description: "")
           ]
         }
@@ -59,21 +61,21 @@ describe "Revisions API" do
     let(:project) { create :project }
     let(:valid_revision_params_with_project) do
       {
-        "revision": {
-          "message": "",
-          "sections":[
+        revision: {
+          url: build(:revision).url,
+          project_id: project.id,
+          sections: [
             document_head_section
-          ],
-          "project_id": project.id
+          ]
         }
       }
     end
 
     let(:valid_revision_params_with_variant) do
       {
-        "revision": {
-          "message": "",
-          "sections":[
+        revision: {
+          url: build(:revision).url,
+          sections: [
             document_head_section(variant: "extended")
           ]
         }
@@ -185,7 +187,7 @@ describe "Revisions API" do
     let(:camelcased_revision) do
       {
         revision: {
-          message: "",
+          url: build(:revision).url,
           sections: [
             {
               "name": "",

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -23,7 +23,7 @@ describe "Revisions API" do
   end
 
   describe "creating a revision" do
-    
+
     let(:valid_revision_params) do
       {
         revision: {
@@ -89,7 +89,7 @@ describe "Revisions API" do
         }.to change { page.revisions.count }.by(1)
 
         expect(response).to be_success
-        expect(Ninetails::Revision.find(json["container"]["revisionId"]).project).to eq project
+        expect(Ninetails::Revision.find(json["container"]["revision"]["id"]).project).to eq project
       end
 
       it "should create a new Project Revision entry if one doesn't exist for this page in the project" do
@@ -97,7 +97,7 @@ describe "Revisions API" do
           post "/pages/#{page.id}/revisions", params: valid_revision_params_with_project
         }.to change { Ninetails::ProjectContainer.count }.by(1)
 
-        revision = Ninetails::Revision.find json["container"]["revisionId"]
+        revision = Ninetails::Revision.find json["container"]["revision"]["id"]
         project_container = Ninetails::ProjectContainer.last
         expect(project_container.container).to eq page
         expect(project_container.project).to eq project
@@ -111,7 +111,7 @@ describe "Revisions API" do
           post "/pages/#{page.id}/revisions", params: valid_revision_params_with_project
         }.to_not change { Ninetails::ProjectContainer.count }
 
-        revision = Ninetails::Revision.find json["container"]["revisionId"]
+        revision = Ninetails::Revision.find json["container"]["revision"]["id"]
         project_container = Ninetails::ProjectContainer.last
         expect(project_container.container).to eq page
         expect(project_container.project).to eq project
@@ -126,7 +126,7 @@ describe "Revisions API" do
         }.to change { page.revisions.count }.by(1)
 
         expect(response).to be_success
-        expect(json["container"]["revisionId"]).to_not be_nil
+        expect(json["container"]["revision"]["id"]).to_not be_nil
       end
 
       it "should have created the correct number of sections" do
@@ -142,7 +142,7 @@ describe "Revisions API" do
         }.to change { page.revisions.count }.by(1)
 
         expect(response).to be_success
-        expect(json["container"]["revisionId"]).to_not be_nil
+        expect(json["container"]["revision"]["id"]).to_not be_nil
       end
 
       it "should have stored the variant" do
@@ -161,7 +161,7 @@ describe "Revisions API" do
       it "should show error messages in the revision params" do
         post "/pages/#{page.id}/revisions", params: invalid_revision_params
 
-        errors = json["container"]["sections"][0]["elements"]["title"]["content"]["errors"]
+        errors = json["container"]["revision"]["sections"][0]["elements"]["title"]["content"]["errors"]
         expect(errors).to eq({ "text"=>["can't be blank"] })
       end
     end
@@ -212,8 +212,8 @@ describe "Revisions API" do
       }.to change { page.revisions.count }.by(1)
 
       expect(response).to be_success
-      expect(json["container"]["revisionId"]).to_not be_nil
-      expect(json["container"]["sections"][0]["elements"]["longNameElement"]["longNameProperty"]["longTextString"]).to_not be_nil
+      expect(json["container"]["revision"]["id"]).to_not be_nil
+      expect(json["container"]["revision"]["sections"][0]["elements"]["longNameElement"]["longNameProperty"]["longTextString"]).to_not be_nil
     end
 
   end


### PR DESCRIPTION
Making revisions include url and published attributes so that you can make a project change a Page's status rather than having url changes happening on live pages all the time.