### PR TITLE
Data sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 !/spec/dummy/log/.keep
 /spec/dummy/tmp
 *.gem
+
+.DS_Store

--- a/app/components/ninetails/section.rb
+++ b/app/components/ninetails/section.rb
@@ -57,6 +57,15 @@ module Ninetails
       elements.find { |element| element.name == name.to_sym }
     end
 
+    def self.has_data(name, builder)
+      @data_sources ||= []
+      @data_sources << { name: name, builder: builder }
+    end
+
+    def self.data_sources
+      @data_sources || []
+    end
+
     def serialize
       {
         name: "",
@@ -64,7 +73,8 @@ module Ninetails
         located_in: self.class.position,
         location_name: self.class.location_name,
         variants: self.class.variants,
-        elements: serialize_elements
+        elements: serialize_elements,
+        data: generate_data
       }
     end
 
@@ -73,6 +83,12 @@ module Ninetails
 
       elements.each_with_object({}) do |element, hash|
         element.add_to_hash hash
+      end
+    end
+
+    def generate_data
+      self.class.data_sources.each_with_object({}) do |data_source, hash|
+        hash[data_source[:name]] = data_source[:builder].call
       end
     end
 

--- a/spec/components/section_spec.rb
+++ b/spec/components/section_spec.rb
@@ -145,4 +145,14 @@ RSpec.describe Ninetails::Section do
     end
   end
 
+  describe "data" do
+    it "should include data in the structure" do
+      expect(Section::SmartSection.new.serialize[:data][:pages]).to eq Car.all
+    end
+
+    it "should default to an empty hash" do
+      expect(ExampleSection.new.serialize[:data]).to eq Hash.new
+    end
+  end
+
 end

--- a/spec/dummy/app/components/section/smart_section.rb
+++ b/spec/dummy/app/components/section/smart_section.rb
@@ -1,0 +1,9 @@
+module Section
+  class SmartSection < Ninetails::Section
+
+    located_in :body
+
+    has_data :pages, -> { Car.all }
+
+  end
+end

--- a/spec/dummy/app/models/car.rb
+++ b/spec/dummy/app/models/car.rb
@@ -1,0 +1,5 @@
+class Car
+  def self.all
+    ["mercedes", "ford", "bmw"]
+  end
+end


### PR DESCRIPTION
Making it possible to include non-editable data in section responses. You can define data keys for a section using the `has_data` attribute:

```ruby
module Section
  class BlogPosts < Ninetails::Section
    located_in :body
    has_data :posts, -> { Post.all }
  end
end
```

This would then reflect in responses:

```json
{
  "type": "BlogPosts",
  "locatedIn": "body",
  "elements": {},
  "data": {
    "posts": "whatever Post.all returns, as json"
  }
}
```

@iZettle/web 