### PR TITLE
Locale & name in revisions

### DIFF
--- a/app/controllers/ninetails/containers_controller.rb
+++ b/app/controllers/ninetails/containers_controller.rb
@@ -34,7 +34,7 @@ module Ninetails
     private
 
     def container_params
-      params.require(:container).permit(:name, :locale, :layout_id)
+      params.fetch(:container, {}).permit :layout_id
     end
 
     def container_class

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -11,8 +11,6 @@ module Ninetails
 
     attr_writer :revision
 
-    validates :locale, presence: true
-
     def self.find_and_load_revision(params, project = nil)
       if params[:id].to_s =~ /^\d+$/
         selector = where id: params[:id]

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -32,6 +32,8 @@ module Ninetails
       self.revision = revisions.build(
         message: params[:message],
         project_id: params[:project_id],
+        locale: params[:locale],
+        name: params[:name],
         url: params[:url]
       )
 

--- a/app/models/ninetails/project_container.rb
+++ b/app/models/ninetails/project_container.rb
@@ -5,6 +5,8 @@ module Ninetails
     belongs_to :revision
     belongs_to :project
 
+    accepts_nested_attributes_for :container, :revision
+
     delegate :name, :locale, :type, :current_revision, to: :container
 
     validates :project, {

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -7,6 +7,7 @@ module Ninetails
     has_many :sections, -> { order :created_at }, through: :revision_sections
 
     validate :sections_are_all_valid, :url_is_unique
+    validates :locale, presence: true
 
     after_create :update_project_container, if: -> { project.present? }
 
@@ -27,11 +28,11 @@ module Ninetails
       project_container.revision = self
       project_container.save
     end
-    
+
     def requires_unique_url?
       container.is_a?(Page) && url.present?
     end
-    
+
     def url_is_unique
       if container.is_a?(Page) && url.present? && Revision.where(url: url).where.not(container: container).exists?
         errors.add :url, "is already in use"

--- a/app/views/ninetails/containers/_container.json.jbuilder
+++ b/app/views/ninetails/containers/_container.json.jbuilder
@@ -1,5 +1,5 @@
 json.container do
-  json.call container, :id, :name, :locale
+  json.call container, :id
   json.type container.type.demodulize
 
   if container.try(:layout).present?

--- a/app/views/ninetails/containers/_container.json.jbuilder
+++ b/app/views/ninetails/containers/_container.json.jbuilder
@@ -8,11 +8,13 @@ json.container do
     end
   end
 
-  json.current_revision do
-    json.partial! "/ninetails/revisions/revision", revision: container.current_revision, container_type: container.class
+  if container.try(:current_revision).present?
+    json.current_revision do
+      json.partial! "/ninetails/revisions/revision", revision: container.current_revision, container_type: container.class
+    end
   end
 
-  if container.revision != container.current_revision
+  if container.try(:revision).present?
     json.revision do
       json.partial! "/ninetails/revisions/revision", revision: container.revision, container_type: container.class
     end

--- a/app/views/ninetails/containers/_container.json.jbuilder
+++ b/app/views/ninetails/containers/_container.json.jbuilder
@@ -12,12 +12,16 @@ json.container do
     json.current_revision do
       json.partial! "/ninetails/revisions/revision", revision: container.current_revision, container_type: container.class
     end
+  else
+    json.current_revision({})
   end
 
   if container.try(:revision).present?
     json.revision do
       json.partial! "/ninetails/revisions/revision", revision: container.revision, container_type: container.class
     end
+  else
+    json.revision({})
   end
 
   if container.errors.present?

--- a/app/views/ninetails/containers/index.json.jbuilder
+++ b/app/views/ninetails/containers/index.json.jbuilder
@@ -5,18 +5,17 @@ json.containers @containers do |container|
     json.call container, :id
   end
 
-  json.call container, :name, :locale
   json.type container.type.demodulize
 
   if container.current_revision.present?
     json.current_revision do
-      json.call container.current_revision, :url, :published
+      json.call container.current_revision, :id, :locale, :name, :url, :published
     end
   end
 
   if container.revision.present?
     json.revision do
-      json.call container.revision, :url, :published
+      json.call container.revision, :id, :locale, :name, :url, :published
     end
   end
 end

--- a/app/views/ninetails/revisions/_revision.json.jbuilder
+++ b/app/views/ninetails/revisions/_revision.json.jbuilder
@@ -1,9 +1,10 @@
 if revision.present?
+  json.call revision, :id, :name, :locale
+
   if container_type.present? && container_type == Ninetails::Page
-    json.call revision, :id, :url, :published
-  else
-    json.call revision, :id
+    json.call revision, :url, :published
   end
+
   json.sections revision.sections, partial: "/ninetails/sections/section", as: :section
 
   if revision.errors.present?

--- a/db/migrate/20170104082424_move_locale_and_name_to_revisions.rb
+++ b/db/migrate/20170104082424_move_locale_and_name_to_revisions.rb
@@ -1,0 +1,33 @@
+class MoveLocaleAndNameToRevisions < ActiveRecord::Migration[5.0]
+  def up
+    add_column :ninetails_revisions, :name, :string
+    add_column :ninetails_revisions, :locale, :string
+
+    execute %{
+      UPDATE ninetails_revisions r
+      SET name = c.name,
+          locale = c.locale
+      FROM ninetails_containers c
+      WHERE r.container_id = c.id
+    }
+
+    remove_column :ninetails_containers, :name
+    remove_column :ninetails_containers, :locale
+  end
+
+  def down
+    add_column :ninetails_containers, :name, :string
+    add_column :ninetails_containers, :locale, :string
+
+    execute %{
+      UPDATE ninetails_containers c
+      SET name = r.name,
+          locale = r.locale
+      FROM ninetails_revisions r
+      WHERE c.id = r.container_id
+    }
+
+    remove_column :ninetails_revisions, :name
+    remove_column :ninetails_revisions, :locale
+  end
+end

--- a/lib/ninetails/seeds/generator.rb
+++ b/lib/ninetails/seeds/generator.rb
@@ -57,13 +57,14 @@ module Ninetails
           container.layout = Ninetails::Layout.find layout
         end
       end
-      
-      def url(url)
-        container.current_revision.url = url
-      end
 
       def method_missing(name, *args, &block)
-        container.public_send "#{name}=", *args
+        # Filter methods which should be set on the revision instead of the container
+        if [:url, :locale, :name].include? name.to_sym
+          container.current_revision.public_send "#{name}=", *args
+        else
+          container.public_send "#{name}=", *args
+        end
       end
     end
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,19 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161227120230) do
+ActiveRecord::Schema.define(version: 20170104082424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "ninetails_containers", force: :cascade do |t|
     t.integer  "current_revision_id"
-    t.string   "name"
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
     t.string   "type",                default: "Ninetails::Page"
     t.integer  "layout_id"
-    t.string   "locale"
     t.datetime "deleted_at"
     t.index ["current_revision_id"], name: "index_ninetails_containers_on_current_revision_id", using: :btree
     t.index ["deleted_at"], name: "index_ninetails_containers_on_deleted_at", using: :btree
@@ -71,6 +69,8 @@ ActiveRecord::Schema.define(version: 20161227120230) do
     t.integer  "project_id"
     t.string   "url"
     t.boolean  "published",    default: false
+    t.string   "name"
+    t.string   "locale"
     t.index ["container_id"], name: "index_ninetails_revisions_on_container_id", using: :btree
     t.index ["project_id"], name: "index_ninetails_revisions_on_project_id", using: :btree
   end

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     end
 
     association :current_revision, factory: :revision
-    locale "en_US"
 
     # The current_revision association is a slightly strange additon to a
     # has_many relationship in FactoryGirl's world, which seems to be causing issues
@@ -39,11 +38,9 @@ FactoryGirl.define do
   end
 
   factory :page, parent: :container, class: Ninetails::Page do
-    name "A page"
   end
 
   factory :layout, parent: :container, class: Ninetails::Layout do
-    name "A layout"
   end
 
 end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -8,6 +8,8 @@ FactoryGirl.define do
   # and all the tests which currently use them, build them manually anyway...
   factory :revision, class: Ninetails::Revision do
     url
+    locale "en_US"
+    name "A page"
   end
 
 end

--- a/spec/lib/seeds/layout_seeds_spec.rb
+++ b/spec/lib/seeds/layout_seeds_spec.rb
@@ -24,8 +24,12 @@ describe Ninetails::Seeds::Generator, "layouts" do
       }.to change{ Ninetails::Layout.count }.by(1)
     end
 
-    it "should set the name of the container" do
-      expect(empty_layout_seed.name).to eq "Main layout"
+    it "should set the name of the revision" do
+      expect(empty_layout_seed.current_revision.name).to eq "Main layout"
+    end
+
+    it "should set the locale of the revision" do
+      expect(empty_layout_seed.current_revision.locale).to eq "en_US"
     end
 
     it "should create a revision" do

--- a/spec/lib/seeds/page_seeds_spec.rb
+++ b/spec/lib/seeds/page_seeds_spec.rb
@@ -47,8 +47,12 @@ describe Ninetails::Seeds::Generator, "pages" do
       }.to change{ Ninetails::Page.count }.by(1)
     end
 
-    it "should set the name of the container" do
-      expect(empty_page.name).to eq "An empty page"
+    it "should set the name of the revision" do
+      expect(empty_page.current_revision.name).to eq "An empty page"
+    end
+
+    it "should set the locale of the revision" do
+      expect(empty_page.current_revision.locale).to eq "en_US"
     end
 
     it "should create a revision" do

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Ninetails::Container, type: :model do
   it { should have_many(:project_containers) }
   it { should belong_to(:current_revision) }
 
-  it { should validate_presence_of(:locale) }
-
   describe ".find_and_load_revision" do
     before do
       @page = create :page, :with_revisions
@@ -84,7 +82,7 @@ RSpec.describe Ninetails::Container, type: :model do
       @container = create :page, revision: @old_revision
       @new_revision = create :revision
     end
-    
+
     it "updates the revision id" do
       expect {
         @container.set_current_revision(@new_revision)

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Ninetails::Revision, type: :model do
   it { should belong_to(:project) }
   it { should have_many(:revision_sections) }
   it { should have_many(:sections).order(:created_at) }
-  
+
+  it { should validate_presence_of(:locale) }
+
   it "should not be published by default" do
     expect(Ninetails::Revision.new.published).to eq false
   end
@@ -19,28 +21,28 @@ RSpec.describe Ninetails::Revision, type: :model do
       create :revision, container: @page, url: nil
       create :revision, container: @page, url: "/foo"
     end
-    
+
     describe "when the url is blank" do
       it "doesn't require a url for Layout revisions" do
         revision = Ninetails::Revision.new container: @layout, url: nil
         revision.valid?
         expect(revision.errors[:url]).to eq []
       end
-      
+
       it "doesn't require a url for Page revisions" do
         revision = Ninetails::Revision.new container: @page, url: nil
         revision.valid?
         expect(revision.errors[:url]).to eq []
       end
     end
-    
+
     describe "when the url is present" do
       it "doesn't allow the url to be used for different containers" do
         revision = Ninetails::Revision.new container: create(:page), url: "/foo"
         revision.valid?
         expect(revision.errors[:url]).to eq ["is already in use"]
       end
-      
+
       it "allows the same url to be used for the same container multiple times" do
         revision = Ninetails::Revision.new container: @page, url: "/foo"
         revision.valid?

--- a/spec/requests/containers_spec.rb
+++ b/spec/requests/containers_spec.rb
@@ -26,22 +26,22 @@ describe "Pages API" do
         expect(json["containers"].size).to eq container_class.count
       end
 
-      it "should include the id and locale for each container" do
+      it "should include the id for each container" do
         get url
 
         json["containers"].each do |container|
           expect(container).to have_key "id"
-          expect(container).to have_key "locale"
-          expect(container).to have_key "name"
         end
       end
 
-      it "should include the url and published from the current_revision" do
+      it "should include the url, name, locale and published from the current_revision" do
         get url
 
         json["containers"].each do |container|
           expect(container["currentRevision"]).to have_key "url"
           expect(container["currentRevision"]).to have_key "published"
+          expect(container["currentRevision"]).to have_key "locale"
+          expect(container["currentRevision"]).to have_key "name"
         end
       end
 
@@ -197,11 +197,7 @@ describe "Pages API" do
       describe "when creating a container" do
         let(:valid_container_params) do
           {
-            container: {
-              name: "A new container in a project",
-              url: "/foobar-project",
-              locale: "en_US"
-            }
+            container: {}
           }
         end
 
@@ -230,18 +226,7 @@ describe "Pages API" do
 
       let(:valid_container_params) do
         {
-          container: {
-            name: "A new container",
-            locale: "en_US"
-          }
-        }
-      end
-
-      let(:page_with_no_locale_params) do
-        {
-          container: {
-            name: "A container"
-          }
+          container: {}
         }
       end
 
@@ -249,13 +234,6 @@ describe "Pages API" do
         expect {
           post url, params: valid_container_params
         }.to change{ container_class.count }.by(1)
-      end
-
-      it "should require a locale" do
-        post url, params: page_with_no_locale_params
-
-        expect(response).to_not be_success
-        expect(json["container"]["errors"]["locale"]).not_to be_empty
       end
 
       it "should have a blank revision id" do
@@ -290,13 +268,6 @@ describe "Pages API" do
 
           expect(response).to be_success
           expect(json["container"]["currentRevision"]["id"]).to eq container.current_revision.id
-        end
-
-        it "should include the container locale" do
-          get url
-
-          expect(response).to be_success
-          expect(json["container"]["locale"]).to eq container.locale
         end
       end
 

--- a/spec/requests/containers_spec.rb
+++ b/spec/requests/containers_spec.rb
@@ -236,14 +236,9 @@ describe "Pages API" do
         }.to change{ container_class.count }.by(1)
       end
 
-      it "should have a blank revision id" do
+      it "should have a blank revision" do
         post url, params: valid_container_params
-        expect(json["container"]["currentRevision"]["id"]).to be_nil
-      end
-
-      it "should have an empty sections array" do
-        post url, params: valid_container_params
-        expect(json["container"]["currentRevision"]["sections"]).to eq []
+        expect(json["container"]["currentRevision"]).to eq({})
       end
 
       it "should create a project container if in the project scope" do

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -28,6 +28,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           sections: [
             document_head_section
           ]
@@ -41,6 +42,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           sections: [
             document_head_section.merge({ "located_in" => "body", "location_name" => "foobar" })
           ]
@@ -64,6 +66,7 @@ describe "Revisions API" do
         revision: {
           url: build(:revision).url,
           project_id: project.id,
+          locale: "en_GB",
           sections: [
             document_head_section
           ]
@@ -75,6 +78,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           sections: [
             document_head_section(variant: "extended")
           ]
@@ -86,6 +90,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           sections: [
             document_head_section(settings: { foo: false })
           ]
@@ -216,6 +221,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           sections: [
             {
               "name": "",


### PR DESCRIPTION
This moves the locale and name attributes from Container to Revision, meaning they're publishable as part of a project, rather than immediately modifying the live, published Container at the time of editing.

@iZettle/web 