### PR TITLE
Folders

### DIFF
--- a/app/controllers/ninetails/folders_controller.rb
+++ b/app/controllers/ninetails/folders_controller.rb
@@ -1,8 +1,43 @@
 module Ninetails
   class FoldersController < NinetailsController
 
+    before_action :find_folder, only: [:update, :destroy]
+
     def index
       @folders = Folder.all
+    end
+
+    def create
+      @folder = Folder.new folder_params
+
+      if @folder.save
+        render :show, status: :created
+      else
+        render :show, status: :bad_request
+      end
+    end
+
+    def update
+      if @folder.update_attributes folder_params
+        render :show, status: :created
+      else
+        render :show, status: :bad_request
+      end
+    end
+
+    def destroy
+      @folder.delete
+      head :no_content
+    end
+
+    private
+
+    def find_folder
+      @folder = Folder.find params[:id]
+    end
+
+    def folder_params
+      params.require(:folder).permit(:name)
     end
 
   end

--- a/app/controllers/ninetails/folders_controller.rb
+++ b/app/controllers/ninetails/folders_controller.rb
@@ -1,0 +1,9 @@
+module Ninetails
+  class FoldersController < NinetailsController
+
+    def index
+      @folders = Folder.all
+    end
+
+  end
+end

--- a/app/controllers/ninetails/folders_controller.rb
+++ b/app/controllers/ninetails/folders_controller.rb
@@ -1,10 +1,13 @@
 module Ninetails
   class FoldersController < NinetailsController
 
-    before_action :find_folder, only: [:update, :destroy]
+    before_action :find_folder, only: [:update, :destroy, :show]
 
     def index
       @folders = Folder.all
+    end
+
+    def show
     end
 
     def create

--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -34,6 +34,7 @@ module Ninetails
         project_id: params[:project_id],
         locale: params[:locale],
         name: params[:name],
+        folder_id: params[:folder_id],
         url: params[:url]
       )
 

--- a/app/models/ninetails/folder.rb
+++ b/app/models/ninetails/folder.rb
@@ -1,0 +1,10 @@
+module Ninetails
+  class Folder < ActiveRecord::Base
+    acts_as_paranoid
+
+    has_many :revisions
+
+    validates :name, uniqueness: true, presence: true
+
+  end
+end

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -3,6 +3,7 @@ module Ninetails
 
     belongs_to :container
     belongs_to :project
+    belongs_to :folder
     has_many :revision_sections
     has_many :sections, -> { order :created_at }, through: :revision_sections
 

--- a/app/models/ninetails/revision.rb
+++ b/app/models/ninetails/revision.rb
@@ -12,6 +12,8 @@ module Ninetails
 
     after_create :update_project_container, if: -> { project.present? }
 
+    scope :live, -> { joins(:container).where("ninetails_revisions.id = ninetails_containers.current_revision_id") }
+
     private
 
     # Validate all sections and rebuild the sections array with the instances which now

--- a/app/views/ninetails/folders/_folder.json.jbuilder
+++ b/app/views/ninetails/folders/_folder.json.jbuilder
@@ -1,0 +1,9 @@
+json.folder do
+  json.call folder, :id, :name, :created_at, :updated_at, :deleted_at
+
+  json.revisions folder.revisions.live, :id, :container_id, :url, :locale, :published
+
+  if folder.errors.present?
+    json.errors folder.errors
+  end
+end

--- a/app/views/ninetails/folders/index.json.jbuilder
+++ b/app/views/ninetails/folders/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.folders @folders, :id, :name

--- a/app/views/ninetails/folders/show.json.jbuilder
+++ b/app/views/ninetails/folders/show.json.jbuilder
@@ -1,7 +1,1 @@
-json.folder do
-  json.call @folder, :id, :name, :created_at, :updated_at, :deleted_at
-
-  if @folder.errors.present?
-    json.errors @folder.errors
-  end
-end
+json.partial! "/ninetails/folders/folder", folder: @folder

--- a/app/views/ninetails/folders/show.json.jbuilder
+++ b/app/views/ninetails/folders/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.folder do
+  json.call @folder, :id, :name, :created_at, :updated_at, :deleted_at
+
+  if @folder.errors.present?
+    json.errors @folder.errors
+  end
+end

--- a/app/views/ninetails/revisions/_revision.json.jbuilder
+++ b/app/views/ninetails/revisions/_revision.json.jbuilder
@@ -1,5 +1,5 @@
 if revision.present?
-  json.call revision, :id, :name, :locale
+  json.call revision, :id, :name, :locale, :folder_id
 
   if container_type.present? && container_type == Ninetails::Page
     json.call revision, :url, :published

--- a/app/views/ninetails/revisions/_revision.json.jbuilder
+++ b/app/views/ninetails/revisions/_revision.json.jbuilder
@@ -5,6 +5,10 @@ if revision.present?
     json.call revision, :url, :published
   end
 
+  if revision.folder.present?
+    json.partial! "/ninetails/folders/folder", folder: revision.folder
+  end
+
   json.sections revision.sections, partial: "/ninetails/sections/section", as: :section
 
   if revision.errors.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Ninetails::Engine.routes.draw do
   with_options defaults: { format: :json } do
     root 'containers#index'
 
+    resources :folders, only: [:index]
+
     resources :projects, except: [:new, :edit] do
       post :publish, on: :member
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Ninetails::Engine.routes.draw do
   with_options defaults: { format: :json } do
     root 'containers#index'
 
-    resources :folders, only: [:index]
+    resources :folders, except: [:new, :edit]
 
     resources :projects, except: [:new, :edit] do
       post :publish, on: :member

--- a/db/migrate/20170102154036_create_ninetails_folders.rb
+++ b/db/migrate/20170102154036_create_ninetails_folders.rb
@@ -1,0 +1,8 @@
+class CreateNinetailsFolders < ActiveRecord::Migration[5.0]
+  def change
+    create_table :ninetails_folders do |t|
+      t.string :name
+      t.timestamp :deleted_at
+    end
+  end
+end

--- a/db/migrate/20170102154036_create_ninetails_folders.rb
+++ b/db/migrate/20170102154036_create_ninetails_folders.rb
@@ -3,6 +3,7 @@ class CreateNinetailsFolders < ActiveRecord::Migration[5.0]
     create_table :ninetails_folders do |t|
       t.string :name
       t.timestamp :deleted_at
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20170102160210_add_folder_to_revisions.rb
+++ b/db/migrate/20170102160210_add_folder_to_revisions.rb
@@ -1,0 +1,5 @@
+class AddFolderToRevisions < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :ninetails_revisions, :folder
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -40,6 +40,8 @@ ActiveRecord::Schema.define(version: 20170104082424) do
   create_table "ninetails_folders", force: :cascade do |t|
     t.string   "name"
     t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "ninetails_project_containers", force: :cascade do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -37,6 +37,11 @@ ActiveRecord::Schema.define(version: 20170104082424) do
     t.json     "settings",   default: {}
   end
 
+  create_table "ninetails_folders", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "deleted_at"
+  end
+
   create_table "ninetails_project_containers", force: :cascade do |t|
     t.integer "project_id"
     t.integer "container_id"
@@ -71,7 +76,9 @@ ActiveRecord::Schema.define(version: 20170104082424) do
     t.boolean  "published",    default: false
     t.string   "name"
     t.string   "locale"
+    t.integer  "folder_id"
     t.index ["container_id"], name: "index_ninetails_revisions_on_container_id", using: :btree
+    t.index ["folder_id"], name: "index_ninetails_revisions_on_folder_id", using: :btree
     t.index ["project_id"], name: "index_ninetails_revisions_on_project_id", using: :btree
   end
 

--- a/spec/factories/containers.rb
+++ b/spec/factories/containers.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
   factory :container, class: Ninetails::Container do
     transient do
       sections []
+      folder nil
     end
 
     association :current_revision, factory: :revision
@@ -12,9 +13,17 @@ FactoryGirl.define do
     # with newly created "current_revision" revisions not having a container_id. So this
     # manually fixes that.
     after :create do |container, evaluator|
+      revision_attrs = {}
+
       if container.current_revision.present? && container.current_revision.container_id.nil?
-        container.current_revision.update_attributes container_id: container.id
+        revision_attrs[:container_id] = container.id
       end
+
+      if evaluator.folder.present?
+        revision_attrs[:folder_id] = evaluator.folder.id
+      end
+
+      container.current_revision.update_attributes revision_attrs
 
       if evaluator.sections.present?
         evaluator.sections.each do |section_name|

--- a/spec/factories/folders.rb
+++ b/spec/factories/folders.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+
+  factory :folder, class: Ninetails::Folder do
+    sequence(:name) { |n| "Some folder #{n}" }
+  end
+
+end

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe Ninetails::Folder do
+
+  it { should have_many :revisions }
+
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name) }
+
+end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Ninetails::Revision, type: :model do
 
   it { should belong_to(:container) }
   it { should belong_to(:project) }
+  it { should belong_to(:folder) }
   it { should have_many(:revision_sections) }
   it { should have_many(:sections).order(:created_at) }
 

--- a/spec/requests/folders_spec.rb
+++ b/spec/requests/folders_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "Folders API" do
+
+  describe "listing folder" do
+    before do
+      @folders = create_list :folder, 5
+    end
+
+    it "should return all folders" do
+      get "/folders"
+      expect(json["folders"].size).to eq 5
+      expect(json["folders"].first["name"]).to eq @folders.first.name
+    end
+
+    it "should not include deleted folders" do
+      @folders.first.delete
+      get "/folders"
+      expect(json["folders"].size).to eq 4
+      expect(json["folders"].first["name"]).not_to eq @folders.first.name
+    end
+
+  end
+
+end

--- a/spec/requests/folders_spec.rb
+++ b/spec/requests/folders_spec.rb
@@ -81,10 +81,23 @@ describe "Folders API" do
       @second_revision = create :revision, container: @pages.first, folder: @folder
     end
 
-    it "should include the folder name and the url and locale of all pages" do
+    it "should include info about the folder" do
+      get "/folders/#{@folder.id}"
+      expect(response).to be_success
+
+      expect(json["folder"]["id"]).to eq @folder.id
+      expect(json["folder"]["name"]).to eq @folder.name
+    end
+
+    it "should include some info about each revision" do
       get "/folders/#{@folder.id}"
 
-      binding.pry
+      expect(json["folder"]["revisions"].length).to eq 2
+      expect(json["folder"]["revisions"][0]["id"]).to eq @pages[0].current_revision.id
+      expect(json["folder"]["revisions"][0]["url"]).to eq @pages[0].current_revision.url
+
+      expect(json["folder"]["revisions"][1]["id"]).to eq @pages[1].current_revision.id
+      expect(json["folder"]["revisions"][1]["url"]).to eq @pages[1].current_revision.url
     end
   end
 

--- a/spec/requests/folders_spec.rb
+++ b/spec/requests/folders_spec.rb
@@ -74,4 +74,18 @@ describe "Folders API" do
     end
   end
 
+  describe "showing a folder" do
+    before do
+      @folder = create :folder
+      @pages = create_list :page, 2, folder: @folder
+      @second_revision = create :revision, container: @pages.first, folder: @folder
+    end
+
+    it "should include the folder name and the url and locale of all pages" do
+      get "/folders/#{@folder.id}"
+
+      binding.pry
+    end
+  end
+
 end

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -103,6 +103,7 @@ describe "Revisions API" do
       {
         revision: {
           url: build(:revision).url,
+          locale: "en_GB",
           folder_id: folder.id,
           sections: [
             document_head_section

--- a/spec/requests/revisions_spec.rb
+++ b/spec/requests/revisions_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe "Revisions API" do
 
   let(:page) { create :page, :with_revisions, revisions_count: 5 }
+  let(:folder) { create :folder }
 
   describe "listing revisions" do
     describe "with a valid page_id" do
@@ -98,6 +99,18 @@ describe "Revisions API" do
       }
     end
 
+    let(:valid_revision_params_with_folder) do
+      {
+        revision: {
+          url: build(:revision).url,
+          folder_id: folder.id,
+          sections: [
+            document_head_section
+          ]
+        }
+      }
+    end
+
     describe "with valid sections and a project id" do
       it "should create a revision with the project id" do
         expect {
@@ -179,6 +192,17 @@ describe "Revisions API" do
 
         errors = json["container"]["revision"]["sections"][0]["elements"]["title"]["content"]["errors"]
         expect(errors).to eq({ "text"=>["can't be blank"] })
+      end
+    end
+
+    describe "with valid sections and a folder" do
+      it "should store the folder correctly" do
+        expect {
+          post "/pages/#{page.id}/revisions", params: valid_revision_params_with_folder
+        }.to change { page.revisions.count }.by(1)
+
+        expect(response).to be_success
+        expect(json["container"]["revision"]["folderId"]).to eq folder.id
       end
     end
 


### PR DESCRIPTION
Making it possible to group containers under folders (using their revisions). When showing a container, "live" revisions for related containers are listed, along with some basic info about the revision (id, container_id, locale, url, etc - not sections).

@iZettle/web 🍩 