### PR TITLE
Looser property type keys

### DIFF
--- a/app/components/ninetails/property_type.rb
+++ b/app/components/ninetails/property_type.rb
@@ -17,7 +17,7 @@ module Ninetails
     end
 
     def serialized_values=(values)
-      if values.is_a?(Hash) && !values.has_key?(:reference)
+      if values.is_a?(Hash) && !values.with_indifferent_access.has_key?(:reference)
         values[:reference] = SecureRandom.uuid
       end
 

--- a/spec/components/property_type_spec.rb
+++ b/spec/components/property_type_spec.rb
@@ -57,7 +57,16 @@ describe Ninetails::PropertyType do
     describe "when the serialized_values is a hash" do
       it "should not modify a reference if it exists" do
         text_property.serialized_values = { text: "bar", reference: "123" }
-        expect(text_property.serialize).to eq({ text: "bar", reference: "123" })
+        expect(text_property.serialize[:reference]).to eq("123")
+      end
+
+      it "should not matter if the key is passed as a string or a symbol" do
+        text_property.serialized_values = { "text" => "bar", "reference" => "123" }
+        expect(text_property.serialize["text"]).to eq("bar")
+        expect(text_property.serialize[:text]).to eq(nil)
+
+        expect(text_property.serialize["reference"]).to eq("123")
+        expect(text_property.serialize[:reference]).to eq(nil)
       end
 
       it "should generate a reference if the hash doesn't have one" do


### PR DESCRIPTION
Check serialized values `with_indifferent_access` before reassigning references.