### PR TITLE
Preserve element references

### DIFF
--- a/app/components/ninetails/element.rb
+++ b/app/components/ninetails/element.rb
@@ -7,6 +7,7 @@ module Ninetails
     end
 
     def deserialize(input)
+      self.reference = input["reference"] if input["reference"].present?
       properties_instances.collect do |property|
         property.serialized_values = input[property.name.to_s]
       end

--- a/spec/components/element_spec.rb
+++ b/spec/components/element_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe Ninetails::Element do
       expect(element.send(:properties_instances).last).to receive(:serialized_values=).with("text"=>"world")
       element.deserialize hash
     end
+
+    it "should not change the reference" do
+      element.deserialize hash
+      expect(element.reference).to eq hash["reference"]
+    end
   end
 
   describe "deserialization", "with enumerable properties" do


### PR DESCRIPTION
If the element json includes a reference, use this instead of regenerating one