### PR TITLE
Adding reference to sections

### DIFF
--- a/app/models/ninetails/container.rb
+++ b/app/models/ninetails/container.rb
@@ -40,7 +40,7 @@ module Ninetails
       )
 
       params[:sections].each do |section_json|
-        content_section = revision.sections.build section_json.slice(:name, :type, :elements, :variant)
+        content_section = revision.sections.build section_json.slice(:name, :type, :elements, :variant, :reference)
         content_section.store_settings section_json["settings"] if section_json["settings"].present?
       end
     end

--- a/app/views/ninetails/sections/_section.json.jbuilder
+++ b/app/views/ninetails/sections/_section.json.jbuilder
@@ -1,4 +1,4 @@
-json.call section, :id, :name, :type, :located_in, :location_name, :variant, :elements
+json.call section, :id, :name, :type, :located_in, :location_name, :variant, :elements, :reference
 
 if section.settings.present?
   json.call section, :settings

--- a/db/migrate/20170510091102_add_reference_to_sections.rb
+++ b/db/migrate/20170510091102_add_reference_to_sections.rb
@@ -1,0 +1,5 @@
+class AddReferenceToSections < ActiveRecord::Migration[5.0]
+  def change
+    add_column :ninetails_content_sections, :reference, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170206161633) do
+ActiveRecord::Schema.define(version: 20170510091102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 20170206161633) do
     t.datetime "updated_at",              null: false
     t.string   "variant"
     t.json     "settings",   default: {}
+    t.string   "reference"
   end
 
   create_table "ninetails_folders", force: :cascade do |t|

--- a/spec/models/content_section_spec.rb
+++ b/spec/models/content_section_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Ninetails::ContentSection, type: :model do
       {
         "name" => "",
         "type" => "TestSection",
+        "reference" => "a1",
         "elements" => {
           "headline" => {
             "type" => "Text",
@@ -107,6 +108,11 @@ RSpec.describe Ninetails::ContentSection, type: :model do
       it "should create a Section instance" do
         section.deserialize
         expect(section.section).to be_a Section::TestSection
+      end
+
+      it "should include the reference" do
+        section.deserialize
+        expect(section.reference).to eq "a1"
       end
 
       it "should have an array of elements_instances" do


### PR DESCRIPTION
This is useful to make it possible to link sections together by giving them the same reference - so we can say if a section is a modification of an old one, or a new addition to the container.